### PR TITLE
Improvement for Relative Date Display

### DIFF
--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -31,9 +31,7 @@ export function getTimeRelativeToNow(
   date: Date | string | number,
   config: { locale?: string } = { locale: 'en-US' },
 ) {
-  const formatter = new Intl.RelativeTimeFormat(config.locale, {
-    numeric: 'auto',
-  })
+  const formatter = new Intl.RelativeTimeFormat(config.locale)
   let duration = (new Date(date).getTime() - new Date().getTime()) / 1000
 
   for (let i = 0; i <= DIVISIONS.length; i++) {


### PR DESCRIPTION
Change `Intl` to show `last year` or `last month` to `1 year ago` or `1 month ago`