### PR TITLE
Improvement In Custom Modal Title

### DIFF
--- a/src/components/utils/CustomModal/index.tsx
+++ b/src/components/utils/CustomModal/index.tsx
@@ -36,7 +36,7 @@ export default function CustomModal({
       {...props}
     >
       {(title || subtitle) && (
-        <div className='d-flex flex-column w-100 mb-3 mr-4'>
+        <div className='d-flex flex-column w-100 pb-3 pr-4'>
           <h2 className={clsx(styles.CustomModalTitle)}>{title}</h2>
           {subtitle && <MutedSpan className={clsx(title && 'mt-1')}>{subtitle}</MutedSpan>}
         </div>


### PR DESCRIPTION
# Problem
Currently the margin right is not working because its overflowing outside the modal container.
The margin right should have acted as a means to make the title & subtitle not touch the close button.
![image](https://user-images.githubusercontent.com/53143942/207086561-428b46ed-71e4-40d7-83f3-7b9c4081f3d8.png)

# Solution
Change margin in custom modal title to padding
![image](https://user-images.githubusercontent.com/53143942/207086981-a0d6f1ed-5a8c-4a6c-a5a1-b843390ac6fb.png)
