### PR TITLE
Remove nowrap for account names

### DIFF
--- a/src/config/app/polkaverse/polkaverseSpaces.ts
+++ b/src/config/app/polkaverse/polkaverseSpaces.ts
@@ -3,6 +3,8 @@ export default [
   '1',
   // Bill's Polkadot Digest
   '1354',
+  // Substrate Newsletters
+  '10647',
   // DotMarketCap
   '1599',
   // PolkaWarriors

--- a/src/config/connections/main.ts
+++ b/src/config/connections/main.ts
@@ -9,7 +9,7 @@ const mainConfig: SubsocialConfig = {
 
   offchainUrl: 'https://api.subsocial.network',
   offchainWs: 'wss://app.subsocial.network/notif-ws',
-  graphqlUrl: 'https://squid.subsquid.io/subsocial/graphql',
+  // graphqlUrl: 'https://squid.subsquid.io/subsocial/graphql',
 
   ipfsNodeUrl: 'https://ipfs.subsocial.network',
 

--- a/src/styles/subsocial.scss
+++ b/src/styles/subsocial.scss
@@ -838,7 +838,6 @@ hr {
 
 .ui--AddressComponents-address {
   @extend .DfBoldBlackLink;
-  white-space: nowrap;
 }
 
 .DfPostPreview {


### PR DESCRIPTION
# Problem
`white-space: nowrap` for component `Name` and `AuthorPreview` makes problem if the name is too long.
For example:
![image](https://user-images.githubusercontent.com/53143942/208067493-7855658b-31b7-4d64-a3e9-5532c8c1899d.png)
![image](https://user-images.githubusercontent.com/53143942/208067574-e2062d17-260a-4018-a27d-97c1e62faf3f.png)
![image](https://user-images.githubusercontent.com/53143942/208067588-b90cdd70-74b2-4265-9fef-adab70a20a56.png)
