### PR TITLE
Fix Notification Issue and Post Preview Formatting

### DIFF
--- a/src/components/activity/Notification.tsx
+++ b/src/components/activity/Notification.tsx
@@ -246,7 +246,7 @@ const CommentNotification = (props: NotificationProps) => {
   const commentDetails = useSelectPost(commentId)
 
   const rootPostId = commentDetails
-    ? asCommentData(commentDetails.post).struct.rootPostId
+    ? asCommentData(commentDetails.post)?.struct?.rootPostId
     : undefined
   const postDetails = useSelectPost(rootPostId)
 
@@ -264,7 +264,7 @@ const CommentNotification = (props: NotificationProps) => {
       preview={
         <ViewPostLink
           post={post}
-          space={space!.struct}
+          space={space?.struct}
           title={<PostTitleForActivity post={post} />}
         />
       }

--- a/src/config/connections/main.ts
+++ b/src/config/connections/main.ts
@@ -9,7 +9,7 @@ const mainConfig: SubsocialConfig = {
 
   offchainUrl: 'https://api.subsocial.network',
   offchainWs: 'wss://app.subsocial.network/notif-ws',
-  graphqlUrl: 'https://squid.subsquid.io/subsocial/graphql',
+  // graphqlUrl: 'https://squid.subsquid.io/subsocial/graphql',
 
   ipfsNodeUrl: 'https://ipfs.subsocial.network',
 

--- a/src/graphql/apis/mappers.ts
+++ b/src/graphql/apis/mappers.ts
@@ -1,4 +1,4 @@
-import { summarize } from '@subsocial/utils'
+import { summarizeMd } from '@subsocial/utils'
 import { Activity } from 'src/types'
 import { ActivityRequiredFragment } from '../__generated__/ActivityRequiredFragment'
 import { GetPostsData_posts } from '../__generated__/GetPostsData'
@@ -105,7 +105,7 @@ export const mapSimplePostFragment = (post: PostSimpleFragment): PostSimpleFragm
   originalPostId: post.sharedPost?.id,
   rootPostId: post.parentPost?.id,
   ipfsContent: {
-    summary: summarize(post.body ?? '') ?? '',
+    summary: summarizeMd(post.body ?? '').summary ?? '',
     image: post.image ?? '',
     title: post.title ?? '',
     link: post.link ?? undefined,


### PR DESCRIPTION
# Changes
- Fix notification page breaks if you have notification regarding comments, I think its because the space doesn't exist for comments.
- Change `summarize` to `summarizeMd` when creating hotfix `summary` (related to #9) to remove markdown formatting in it