### PR TITLE
Resolve MD text for space description

### DIFF
--- a/src/components/spaces/ViewSpace.tsx
+++ b/src/components/spaces/ViewSpace.tsx
@@ -13,14 +13,13 @@ import { useMyAddress } from '../auth/MyAccountsContext'
 import MakeAsProfileModal from '../profiles/address-views/utils/MakeAsProfileModal'
 import { useIsMobileWidthOrDevice } from '../responsive'
 import { editSpaceUrl } from '../urls'
+import { DfMd } from '../utils/DfMd'
 import { EntityStatusGroup, PendingSpaceOwnershipPanel } from '../utils/EntityStatusPanels'
-import { SummarizeMd } from '../utils/md'
 import { MutedSpan } from '../utils/MutedText'
 import MyEntityLabel from '../utils/MyEntityLabel'
 import Section from '../utils/Section'
 import { BareProps } from '../utils/types'
 import ViewTags from '../utils/ViewTags'
-import AboutSpaceLink from './AboutSpaceLink'
 import {
   HiddenSpaceAlert,
   OfficialSpaceStatus,
@@ -188,10 +187,7 @@ export const InnerViewSpace = (props: Props) => {
 
           {nonEmptyStr(about) && (
             <div className='description mt-3'>
-              <SummarizeMd
-                content={content}
-                more={<AboutSpaceLink space={space} title={'Learn More'} />}
-              />
+              <DfMd source={content.about} />
             </div>
           )}
 

--- a/src/components/spaces/ViewSpacePage.tsx
+++ b/src/components/spaces/ViewSpacePage.tsx
@@ -44,7 +44,7 @@ const InnerViewSpacePage: FC<Props> = props => {
       <PageContent
         meta={{
           title,
-          desc: `Latest news and updates from ${name} on Subsocial.`,
+          desc: `Latest news and updates from ${name} on Polkaverse.`,
           image,
           canonical: spaceUrl(spaceData.struct),
         }}

--- a/src/components/utils/DualAvatar/index.tsx
+++ b/src/components/utils/DualAvatar/index.tsx
@@ -10,7 +10,7 @@ export interface DualAvatarProps extends HTMLProps<HTMLDivElement> {
   rightAvatarSize?: number
 }
 
-const TOP_IMAGE_OFFSET = 60
+const RIGHT_IMAGE_OFFSET = 60
 
 export default function DualAvatar({
   className,
@@ -23,10 +23,10 @@ export default function DualAvatar({
     <div className={clsx(!noMargin && 'mr-2', className)}>
       <div
         className={clsx(styles.DualAvatar)}
-        style={{ marginRight: `${(rightAvatarSize * TOP_IMAGE_OFFSET) / 100}px` }}
+        style={{ marginRight: `${(rightAvatarSize * RIGHT_IMAGE_OFFSET) / 100}px` }}
       >
         <div className={clsx(styles.LeftAvatar)}>{rightAvatar}</div>
-        <div className={clsx(styles.RightAvatar)} style={{ left: `${TOP_IMAGE_OFFSET}%` }}>
+        <div className={clsx(styles.RightAvatar)} style={{ left: `${RIGHT_IMAGE_OFFSET}%` }}>
           {leftAvatar}
         </div>
       </div>

--- a/src/components/utils/DualAvatar/index.tsx
+++ b/src/components/utils/DualAvatar/index.tsx
@@ -10,7 +10,7 @@ export interface DualAvatarProps extends HTMLProps<HTMLDivElement> {
   rightAvatarSize?: number
 }
 
-const RIGHT_IMAGE_OFFSET = 60
+const RIGHT_IMAGE_OFFSET = 50
 
 export default function DualAvatar({
   className,


### PR DESCRIPTION
# Main Change
Currently, the space description is just summarized data.
This PR changes that so the description will show the full about with all the md formatting in it.
example: 
Before:
![image](https://user-images.githubusercontent.com/53143942/211540761-08fd2961-74d2-43c3-99b9-ed68f789779b.png)
After:
![image](https://user-images.githubusercontent.com/53143942/211540717-68c39899-9fb0-4089-86a1-770aabf57370.png)

# Other Changes
- Rename offset variable name in `DualAvatar` because the context is wrong.
- Change the meta desc in space page from `... on Subsocial` to `... on Polkaverse`
- Change the offset of dual avatar so the images are a bit closer