### PR TITLE
Fix infinite loading when opening account page

### DIFF
--- a/src/rtk/features/spaceIds/ownSpaceIdsSlice.ts
+++ b/src/rtk/features/spaceIds/ownSpaceIdsSlice.ts
@@ -53,7 +53,7 @@ export const fetchSpaceIdsOwnedByAccount = createAsyncThunk<
     ? findSpaceIdsThatCanSuggestIfSudo(sudoOne, myAddress, allSpaceIds)
     : allSpaceIds
 
-  dispatch(fetchPostIdsOwnedByAccount({ ...args, spaceIds }))
+  await dispatch(fetchPostIdsOwnedByAccount({ ...args, spaceIds }))
 
   return {
     id: myAddress,


### PR DESCRIPTION
# Problem
Currently, when I open any account's profile page, it just infinitely loading.
This is because in SSR part, after fetching space ids, it should fetch post ids.

That works, but fetch posts are slow and it don't get awaited, so it don't get inserted to the initial state of redux when hydrating in frontend.
![image](https://user-images.githubusercontent.com/53143942/212328286-f9380f18-e3cf-4dbd-8033-be7e663a4b8d.png)

# Solution
await the fetch post ids, so because in getInitialProps, it awaited the fetch space ids, it automatically waits for post ids to finish as well.

# Drawback
For fetching in frontend part, it may become slower as the web can't fetch the space data from space ids or show them before the post ids finish fetching too.
