### PR TITLE
Enable Squid and Add Fallback for IPFS Content

### DIFF
--- a/src/config/availableFeatures.ts
+++ b/src/config/availableFeatures.ts
@@ -5,7 +5,7 @@ import { featureOverrides as env } from './env'
 import { CommonSubsocialFeatures, SubsocialFeatures } from './types'
 import { getOrFalse, getOrTrue } from './utils'
 
-const enableGraphQl = getOrTrue(false) && nonEmptyStr(connections.graphqlUrl)
+const enableGraphQl = getOrTrue(env.enableGraphQl) && nonEmptyStr(connections.graphqlUrl)
 const commonFeatures: CommonSubsocialFeatures = {
   enableSearch: getOrTrue(env.enableSearch),
   enableFeed: getOrTrue(env.enableFeed),

--- a/src/config/availableFeatures.ts
+++ b/src/config/availableFeatures.ts
@@ -17,7 +17,7 @@ const commonFeatures: CommonSubsocialFeatures = {
   enableGraphQl,
   enableSubnetMode: nonEmptyStr(app.subnetId),
   enableContributionPage: getOrTrue(env.enableContributionPage),
-  enableOnchainActivities: getOrFalse(true),
+  enableOnchainActivities: getOrFalse(!enableGraphQl),
   enableDomains: getOrFalse(true),
   enableSquidDataSource: getOrTrue(env.enableSquidDataSource) && enableGraphQl,
 }

--- a/src/graphql/apis/mappers.ts
+++ b/src/graphql/apis/mappers.ts
@@ -61,19 +61,8 @@ export const mapSimpleProfileFragment = ({
   spaceId: profileSpace?.id ?? '',
 })
 
-export const mapSimpleSpaceFragment = (space: SpaceSimpleFragment): SpaceSimpleFragmentMapped => ({
-  canEveryoneCreatePosts: space.canEveryoneCreatePosts ?? false,
-  canFollowerCreatePosts: space.canFollowerCreatePosts ?? false,
-  createdAtBlock: space.createdAtBlock,
-  createdAtTime: space.createdAtTime,
-  createdByAccount: space.createdByAccount.id,
-  hidden: space.hidden,
-  id: space.id,
-  ownerId: space.ownedByAccount.id,
-  contentId: space.content ?? '',
-  handle: undefined,
-  postsCount: space.postsCount,
-  ipfsContent: {
+export const mapSimpleSpaceFragment = (space: SpaceSimpleFragment): SpaceSimpleFragmentMapped => {
+  const getContent = () => ({
     image: space.image ?? '',
     name: space.name ?? '',
     tags: getTokensFromUnifiedString(space.tagsOriginal),
@@ -82,39 +71,61 @@ export const mapSimpleSpaceFragment = (space: SpaceSimpleFragment): SpaceSimpleF
     email: space.email ?? '',
     links: getTokensFromUnifiedString(space.linksOriginal),
     isShowMore: false,
-  },
-})
+  })
+  const isIpfsDataError =
+    space.content && !space.name && !space.image && !space.about && !space.email
+  return {
+    canEveryoneCreatePosts: space.canEveryoneCreatePosts ?? false,
+    canFollowerCreatePosts: space.canFollowerCreatePosts ?? false,
+    createdAtBlock: space.createdAtBlock,
+    createdAtTime: space.createdAtTime,
+    createdByAccount: space.createdByAccount.id,
+    hidden: space.hidden,
+    id: space.id,
+    ownerId: space.ownedByAccount.id,
+    contentId: space.content ?? '',
+    handle: undefined,
+    postsCount: space.postsCount,
+    ipfsContent: isIpfsDataError ? undefined : getContent(),
+  }
+}
 
-export const mapSimplePostFragment = (post: PostSimpleFragment): PostSimpleFragmentMapped => ({
-  createdAtBlock: parseInt(post.createdAtBlock),
-  createdAtTime: new Date(post.createdAtTime).getTime(),
-  createdByAccount: post.createdByAccount.id,
-  downvotesCount: post.downvotesCount,
-  hidden: post.hidden,
-  id: post.id,
-  isComment: post.isComment,
-  isRegularPost: post.kind === 'RegularPost',
-  isSharedPost: post.kind === 'SharedPost',
-  ownerId: post.ownedByAccount.id,
-  upvotesCount: post.upvotesCount,
-  contentId: post.content ?? '',
-  repliesCount: post.repliesCount,
-  sharesCount: post.sharesCount,
-  spaceId: post.space?.id,
-  isUpdated: !!post.updatedAtTime,
-  originalPostId: post.sharedPost?.id,
-  rootPostId: post.parentPost?.id,
-  ipfsContent: {
-    summary: summarizeMd(post.body ?? '').summary ?? '',
-    image: post.image ?? '',
-    title: post.title ?? '',
-    link: post.link ?? undefined,
-    body: '',
-    canonical: post.canonical ?? '',
-    isShowMore: false,
-    tags: getTokensFromUnifiedString(post.tagsOriginal),
-  },
-})
+export const mapSimplePostFragment = (post: PostSimpleFragment): PostSimpleFragmentMapped => {
+  const getContent = () => {
+    return {
+      summary: summarizeMd(post.body ?? '').summary ?? '',
+      image: post.image ?? '',
+      title: post.title ?? '',
+      link: post.link ?? undefined,
+      body: '',
+      canonical: post.canonical ?? '',
+      isShowMore: false,
+      tags: getTokensFromUnifiedString(post.tagsOriginal),
+    }
+  }
+  const isIpfsDataError = post.content && !post.body && !post.image && !post.title
+  return {
+    createdAtBlock: parseInt(post.createdAtBlock),
+    createdAtTime: new Date(post.createdAtTime).getTime(),
+    createdByAccount: post.createdByAccount.id,
+    downvotesCount: post.downvotesCount,
+    hidden: post.hidden,
+    id: post.id,
+    isComment: post.isComment,
+    isRegularPost: post.kind === 'RegularPost',
+    isSharedPost: post.kind === 'SharedPost',
+    ownerId: post.ownedByAccount.id,
+    upvotesCount: post.upvotesCount,
+    contentId: post.content ?? '',
+    repliesCount: post.repliesCount,
+    sharesCount: post.sharesCount,
+    spaceId: post.space?.id,
+    isUpdated: !!post.updatedAtTime,
+    originalPostId: post.sharedPost?.id,
+    rootPostId: post.parentPost?.id,
+    ipfsContent: isIpfsDataError ? undefined : getContent(),
+  }
+}
 
 export const mapProfileFragment = (profile: ProfileFragment): ProfileFragmentMapped => ({
   ...mapSimpleProfileFragment(profile),

--- a/src/graphql/apis/types.ts
+++ b/src/graphql/apis/types.ts
@@ -2,11 +2,11 @@ import { PostContent, PostStruct, SpaceContent, SpaceStruct } from '@subsocial/a
 import { ProfileSpaceIdByAccount } from 'src/types'
 
 // Simple Fragment Results
-export type SpaceSimpleFragmentMapped = SpaceStruct & { ipfsContent: SpaceContent }
+export type SpaceSimpleFragmentMapped = SpaceStruct & { ipfsContent?: SpaceContent }
 export type PostSimpleFragmentMapped = PostStruct & {
   originalPostId?: string
   rootPostId?: string
-} & { ipfsContent: PostContent }
+} & { ipfsContent?: PostContent }
 export type ProfileSimpleFragmentMapped = ProfileSpaceIdByAccount
 
 // Full Fragment Results

--- a/src/rtk/features/posts/postsSlice.ts
+++ b/src/rtk/features/posts/postsSlice.ts
@@ -242,10 +242,11 @@ export const fetchPosts = createAsyncThunk<PostStruct[], FetchPostsArgs, ThunkAp
         const ids = getUniqueContentIds(entities)
         const prefetchedData = generatePrefetchData<Content>(
           data => data.contentId,
-          data => ({
-            id: data.contentId ?? '',
-            ...data.ipfsContent,
-          }),
+          data =>
+            data.ipfsContent && {
+              id: data.contentId ?? '',
+              ...data.ipfsContent,
+            },
         )
         if (ids.length) {
           fetches.push(dispatch(fetchContents({ api, ids, dataSource, prefetchedData })))

--- a/src/rtk/features/spaces/spacesSlice.ts
+++ b/src/rtk/features/spaces/spacesSlice.ts
@@ -180,10 +180,11 @@ export const fetchSpaces = createAsyncThunk<SpaceStruct[], FetchSpacesArgs, Thun
         const ids = getUniqueContentIds(entities)
         const prefetchedData = generatePrefetchData<Content>(
           data => data.contentId,
-          data => ({
-            id: data.contentId ?? '',
-            ...data.ipfsContent,
-          }),
+          data =>
+            data.ipfsContent && {
+              id: data.contentId ?? '',
+              ...data.ipfsContent,
+            },
         )
         if (ids.length) {
           fetches.push(dispatch(fetchContents({ api, ids, prefetchedData, dataSource })))


### PR DESCRIPTION
Previously, if squid ipfs content is not right (it have ipfs cid, but the content like body, image, etc. is empty), it will just assume that's the correct data.

With this change, it detects if the ipfs content from graphql is error or not, by checking if the content cid is there, but the content inside is not there (specific checks in `mappers.ts`)
If its marked as error, then it will not use the ipfs content from graphql, but it will fetch the content from IPFS node.

Before:
![image](https://user-images.githubusercontent.com/53143942/212374604-0f80c524-5f7b-473d-8e1a-a095e4673c18.png)

After:
![image](https://user-images.githubusercontent.com/53143942/212374566-2aa6c4dd-ea06-4d3d-af92-9a6eb9aa9cb6.png)