### PR TITLE
Improvement for Space About Preview

### DIFF
--- a/src/components/posts/view-post/helpers.tsx
+++ b/src/components/posts/view-post/helpers.tsx
@@ -219,7 +219,7 @@ const PostSummary = React.memo(({ space, post }: PostSummaryProps) => {
   const { content } = post
   if (!content) return null
 
-  const seeMoreLink = <BlackPostLink space={space!} post={post} title='See More' />
+  const seeMoreLink = <BlackPostLink space={space!} post={post} title='View Full Post' />
   return <SummarizeMd content={content} more={seeMoreLink} />
 })
 

--- a/src/components/posts/view-post/helpers.tsx
+++ b/src/components/posts/view-post/helpers.tsx
@@ -219,7 +219,7 @@ const PostSummary = React.memo(({ space, post }: PostSummaryProps) => {
   const { content } = post
   if (!content) return null
 
-  const seeMoreLink = <BlackPostLink space={space!} post={post} title='View Full Post' />
+  const seeMoreLink = <BlackPostLink space={space!} post={post} title='View Post' />
   return <SummarizeMd content={content} more={seeMoreLink} />
 })
 

--- a/src/components/spaces/ViewSpace.tsx
+++ b/src/components/spaces/ViewSpace.tsx
@@ -1,7 +1,7 @@
 import { EditOutlined } from '@ant-design/icons'
 import { isEmptyStr, newLogger, nonEmptyStr } from '@subsocial/utils'
 import dynamic from 'next/dynamic'
-import React, { useCallback } from 'react'
+import React, { MouseEvent, useCallback, useState } from 'react'
 import { Donate } from 'src/components/donate'
 import { ButtonLink } from 'src/components/utils/CustomLinks'
 import { Segment } from 'src/components/utils/Segment'
@@ -13,6 +13,7 @@ import { useMyAddress } from '../auth/MyAccountsContext'
 import MakeAsProfileModal from '../profiles/address-views/utils/MakeAsProfileModal'
 import { useIsMobileWidthOrDevice } from '../responsive'
 import { editSpaceUrl } from '../urls'
+import { DfMd } from '../utils/DfMd'
 import { EntityStatusGroup, PendingSpaceOwnershipPanel } from '../utils/EntityStatusPanels'
 import { SummarizeMd } from '../utils/md'
 import { MutedSpan } from '../utils/MutedText'
@@ -20,7 +21,6 @@ import MyEntityLabel from '../utils/MyEntityLabel'
 import Section from '../utils/Section'
 import { BareProps } from '../utils/types'
 import ViewTags from '../utils/ViewTags'
-import AboutSpaceLink from './AboutSpaceLink'
 import {
   HiddenSpaceAlert,
   OfficialSpaceStatus,
@@ -70,6 +70,7 @@ export const InnerViewSpace = (props: Props) => {
     withStats = true,
     withTags = true,
     withTipButton = true,
+    showFullAbout = false,
     dropdownPreview = false,
 
     postIds = [],
@@ -80,6 +81,7 @@ export const InnerViewSpace = (props: Props) => {
   } = props
   const isMobile = useIsMobileWidthOrDevice()
   const address = useMyAddress()
+  const [collapseAbout, setCollapseAbout] = useState(true)
 
   const spaceData = useSelectSpace(initialSpaceData?.id)
   const isMy = useIsMySpace(spaceData?.struct)
@@ -156,6 +158,11 @@ export const InnerViewSpace = (props: Props) => {
     </span>,
   )
 
+  const onToggleShow = (e: MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setCollapseAbout(prev => !prev)
+  }
   const renderPreview = () => (
     <div className={primaryClass}>
       <div className='DfSpaceBody'>
@@ -187,11 +194,35 @@ export const InnerViewSpace = (props: Props) => {
           </div>
 
           {nonEmptyStr(about) && (
-            <div className='description mt-3'>
-              <SummarizeMd
-                content={content}
-                more={<AboutSpaceLink space={space} title={'Learn More'} />}
-              />
+            <div className='description mt-3 d-block'>
+              {showFullAbout || !collapseAbout ? (
+                <>
+                  <DfMd source={content.about} />
+                  {!showFullAbout && (
+                    <div
+                      className='DfBlackLink font-weight-semibold mt-1 FontNormal'
+                      onClick={onToggleShow}
+                    >
+                      Show Less
+                    </div>
+                  )}
+                </>
+              ) : (
+                <ViewSpaceLink
+                  space={space}
+                  className='description mt-3 d-block'
+                  title={
+                    <SummarizeMd
+                      content={content}
+                      more={
+                        <span className='DfBlackLink font-weight-semibold' onClick={onToggleShow}>
+                          Show More
+                        </span>
+                      }
+                    />
+                  }
+                />
+              )}
             </div>
           )}
 

--- a/src/components/spaces/ViewSpace.tsx
+++ b/src/components/spaces/ViewSpace.tsx
@@ -1,7 +1,7 @@
 import { EditOutlined } from '@ant-design/icons'
 import { isEmptyStr, newLogger, nonEmptyStr } from '@subsocial/utils'
 import dynamic from 'next/dynamic'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback } from 'react'
 import { Donate } from 'src/components/donate'
 import { ButtonLink } from 'src/components/utils/CustomLinks'
 import { Segment } from 'src/components/utils/Segment'
@@ -13,7 +13,6 @@ import { useMyAddress } from '../auth/MyAccountsContext'
 import MakeAsProfileModal from '../profiles/address-views/utils/MakeAsProfileModal'
 import { useIsMobileWidthOrDevice } from '../responsive'
 import { editSpaceUrl } from '../urls'
-import { DfMd } from '../utils/DfMd'
 import { EntityStatusGroup, PendingSpaceOwnershipPanel } from '../utils/EntityStatusPanels'
 import { SummarizeMd } from '../utils/md'
 import { MutedSpan } from '../utils/MutedText'
@@ -79,7 +78,6 @@ export const InnerViewSpace = (props: Props) => {
 
     onClick,
   } = props
-  const [collapseAbout, setCollapseAbout] = useState(true)
   const isMobile = useIsMobileWidthOrDevice()
   const address = useMyAddress()
 
@@ -189,18 +187,11 @@ export const InnerViewSpace = (props: Props) => {
           </div>
 
           {nonEmptyStr(about) && (
-            <div
-              className='description mt-3 CursorPointer'
-              onClick={() => setCollapseAbout(prev => !prev)}
-            >
-              {collapseAbout ? (
-                <SummarizeMd
-                  content={content}
-                  more={<AboutSpaceLink space={space} title={'Learn More'} />}
-                />
-              ) : (
-                <DfMd source={content.about} />
-              )}
+            <div className='description mt-3'>
+              <SummarizeMd
+                content={content}
+                more={<AboutSpaceLink space={space} title={'Learn More'} />}
+              />
             </div>
           )}
 

--- a/src/components/spaces/ViewSpace.tsx
+++ b/src/components/spaces/ViewSpace.tsx
@@ -189,7 +189,10 @@ export const InnerViewSpace = (props: Props) => {
           </div>
 
           {nonEmptyStr(about) && (
-            <div className='description mt-3' onClick={() => setCollapseAbout(prev => !prev)}>
+            <div
+              className='description mt-3 CursorPointer'
+              onClick={() => setCollapseAbout(prev => !prev)}
+            >
               {collapseAbout ? (
                 <SummarizeMd
                   content={content}

--- a/src/components/spaces/ViewSpace.tsx
+++ b/src/components/spaces/ViewSpace.tsx
@@ -13,13 +13,14 @@ import { useMyAddress } from '../auth/MyAccountsContext'
 import MakeAsProfileModal from '../profiles/address-views/utils/MakeAsProfileModal'
 import { useIsMobileWidthOrDevice } from '../responsive'
 import { editSpaceUrl } from '../urls'
-import { DfMd } from '../utils/DfMd'
 import { EntityStatusGroup, PendingSpaceOwnershipPanel } from '../utils/EntityStatusPanels'
+import { SummarizeMd } from '../utils/md'
 import { MutedSpan } from '../utils/MutedText'
 import MyEntityLabel from '../utils/MyEntityLabel'
 import Section from '../utils/Section'
 import { BareProps } from '../utils/types'
 import ViewTags from '../utils/ViewTags'
+import AboutSpaceLink from './AboutSpaceLink'
 import {
   HiddenSpaceAlert,
   OfficialSpaceStatus,
@@ -187,7 +188,10 @@ export const InnerViewSpace = (props: Props) => {
 
           {nonEmptyStr(about) && (
             <div className='description mt-3'>
-              <DfMd source={content.about} />
+              <SummarizeMd
+                content={content}
+                more={<AboutSpaceLink space={space} title={'Learn More'} />}
+              />
             </div>
           )}
 

--- a/src/components/spaces/ViewSpace.tsx
+++ b/src/components/spaces/ViewSpace.tsx
@@ -1,7 +1,7 @@
 import { EditOutlined } from '@ant-design/icons'
 import { isEmptyStr, newLogger, nonEmptyStr } from '@subsocial/utils'
 import dynamic from 'next/dynamic'
-import React, { useCallback } from 'react'
+import React, { useCallback, useState } from 'react'
 import { Donate } from 'src/components/donate'
 import { ButtonLink } from 'src/components/utils/CustomLinks'
 import { Segment } from 'src/components/utils/Segment'
@@ -13,6 +13,7 @@ import { useMyAddress } from '../auth/MyAccountsContext'
 import MakeAsProfileModal from '../profiles/address-views/utils/MakeAsProfileModal'
 import { useIsMobileWidthOrDevice } from '../responsive'
 import { editSpaceUrl } from '../urls'
+import { DfMd } from '../utils/DfMd'
 import { EntityStatusGroup, PendingSpaceOwnershipPanel } from '../utils/EntityStatusPanels'
 import { SummarizeMd } from '../utils/md'
 import { MutedSpan } from '../utils/MutedText'
@@ -78,6 +79,7 @@ export const InnerViewSpace = (props: Props) => {
 
     onClick,
   } = props
+  const [collapseAbout, setCollapseAbout] = useState(true)
   const isMobile = useIsMobileWidthOrDevice()
   const address = useMyAddress()
 
@@ -187,11 +189,15 @@ export const InnerViewSpace = (props: Props) => {
           </div>
 
           {nonEmptyStr(about) && (
-            <div className='description mt-3'>
-              <SummarizeMd
-                content={content}
-                more={<AboutSpaceLink space={space} title={'Learn More'} />}
-              />
+            <div className='description mt-3' onClick={() => setCollapseAbout(prev => !prev)}>
+              {collapseAbout ? (
+                <SummarizeMd
+                  content={content}
+                  more={<AboutSpaceLink space={space} title={'Learn More'} />}
+                />
+              ) : (
+                <DfMd source={content.about} />
+              )}
             </div>
           )}
 

--- a/src/components/spaces/ViewSpacePage.tsx
+++ b/src/components/spaces/ViewSpacePage.tsx
@@ -57,7 +57,7 @@ const InnerViewSpacePage: FC<Props> = props => {
             desc='You can claim ownership for free!'
           />
         )}
-        <ViewSpace {...props} />
+        <ViewSpace {...props} showFullAbout />
       </PageContent>
     </>
   )

--- a/src/components/spaces/ViewSpaceProps.ts
+++ b/src/components/spaces/ViewSpaceProps.ts
@@ -11,6 +11,7 @@ export type ViewSpaceOptsProps = {
   withTags?: boolean
   withStats?: boolean
   withTipButton?: boolean
+  showFullAbout?: boolean
   imageSize?: number
 }
 

--- a/src/components/spaces/helpers/loadSpaceOnNextReq.ts
+++ b/src/components/spaces/helpers/loadSpaceOnNextReq.ts
@@ -1,3 +1,4 @@
+import router from 'next/router'
 import { slugifyDomain } from 'src/components/domains/utils'
 import { getSpaceId } from 'src/components/substrate'
 import { return404 } from 'src/components/utils/next'
@@ -33,13 +34,18 @@ export async function loadSpaceOnNextReq(
 
     const handle = slugifyDomain(maybeHandle)
 
-    if ((!handle || handle !== idOrHandle) && res) {
+    if (!handle || handle !== idOrHandle) {
       const owner = spaceData.struct.ownerId
       const handleFromChain = await subsocial.blockchain.domainNameBySpaceId(owner, idStr)
 
       if (handleFromChain) {
-        res.writeHead(301, { Location: getCanonicalUrl({ id: idStr, handle: handleFromChain }) })
-        res.end()
+        const expectedUrl = getCanonicalUrl({ id: idStr, handle: handleFromChain })
+        if (res) {
+          res.writeHead(301, { Location: expectedUrl })
+          res.end()
+        } else {
+          router.push(expectedUrl)
+        }
       }
     }
 

--- a/src/components/utils/md/SummarizeMd.tsx
+++ b/src/components/utils/md/SummarizeMd.tsx
@@ -16,7 +16,7 @@ type Props = {
 
 export const SummarizeMd = React.memo((props: Props) => {
   const { content, limit: initialLimit, more, className, ...otherProps } = props
-  const { summary: initialSummary = '', isShowMore = false } = content || {}
+  const { summary: initialSummary = '', isShowMore: initialIsShowMore = false } = content || {}
   const isMobile = useIsMobileWidthOrDevice()
 
   if (isEmptyStr(initialSummary)) return null
@@ -24,6 +24,7 @@ export const SummarizeMd = React.memo((props: Props) => {
   const limit = initialLimit ? initialLimit : isMobile ? MOBILE_SUMMARY_LEN : DESKTOP_SUMMARY_LEN
 
   const summary = summarize(initialSummary, { limit })
+  let isShowMore = initialIsShowMore || initialSummary.length > limit
 
   if (isEmptyStr(summary)) return null
 

--- a/src/components/utils/md/SummarizeMd.tsx
+++ b/src/components/utils/md/SummarizeMd.tsx
@@ -31,7 +31,12 @@ export const SummarizeMd = React.memo((props: Props) => {
   return (
     <div className={clsx('DfSummary', className)} {...otherProps}>
       {summary}
-      {isShowMore && <span className='DfSeeMore'> {more}</span>}
+      {isShowMore && (
+        <span className='DfSeeMore' onClick={e => e.stopPropagation()}>
+          {' '}
+          {more}
+        </span>
+      )}
     </div>
   )
 })

--- a/src/graphql/__generated__/GetPostsData.ts
+++ b/src/graphql/__generated__/GetPostsData.ts
@@ -47,7 +47,6 @@ export interface GetPostsData_posts_ownedByAccount_profileSpace {
   postsCount: number;
   image: string | null;
   tagsOriginal: string | null;
-  summary: string | null;
   about: string | null;
   ownedByAccount: GetPostsData_posts_ownedByAccount_profileSpace_ownedByAccount;
 }
@@ -97,7 +96,6 @@ export interface GetPostsData_posts_space_ownedByAccount_profileSpace {
   postsCount: number;
   image: string | null;
   tagsOriginal: string | null;
-  summary: string | null;
   about: string | null;
   ownedByAccount: GetPostsData_posts_space_ownedByAccount_profileSpace_ownedByAccount;
 }
@@ -126,7 +124,6 @@ export interface GetPostsData_posts_space {
   postsCount: number;
   image: string | null;
   tagsOriginal: string | null;
-  summary: string | null;
   about: string | null;
   ownedByAccount: GetPostsData_posts_space_ownedByAccount;
 }
@@ -169,7 +166,6 @@ export interface GetPostsData_posts_parentPost_ownedByAccount_profileSpace {
   postsCount: number;
   image: string | null;
   tagsOriginal: string | null;
-  summary: string | null;
   about: string | null;
   ownedByAccount: GetPostsData_posts_parentPost_ownedByAccount_profileSpace_ownedByAccount;
 }
@@ -219,7 +215,6 @@ export interface GetPostsData_posts_parentPost_space_ownedByAccount_profileSpace
   postsCount: number;
   image: string | null;
   tagsOriginal: string | null;
-  summary: string | null;
   about: string | null;
   ownedByAccount: GetPostsData_posts_parentPost_space_ownedByAccount_profileSpace_ownedByAccount;
 }
@@ -248,7 +243,6 @@ export interface GetPostsData_posts_parentPost_space {
   postsCount: number;
   image: string | null;
   tagsOriginal: string | null;
-  summary: string | null;
   about: string | null;
   ownedByAccount: GetPostsData_posts_parentPost_space_ownedByAccount;
 }
@@ -271,7 +265,6 @@ export interface GetPostsData_posts_parentPost {
   createdAtTime: any | null;
   createdByAccount: GetPostsData_posts_parentPost_createdByAccount;
   title: string | null;
-  summary: string | null;
   body: string | null;
   image: string | null;
   link: string | null;
@@ -329,7 +322,6 @@ export interface GetPostsData_posts_sharedPost_ownedByAccount_profileSpace {
   postsCount: number;
   image: string | null;
   tagsOriginal: string | null;
-  summary: string | null;
   about: string | null;
   ownedByAccount: GetPostsData_posts_sharedPost_ownedByAccount_profileSpace_ownedByAccount;
 }
@@ -379,7 +371,6 @@ export interface GetPostsData_posts_sharedPost_space_ownedByAccount_profileSpace
   postsCount: number;
   image: string | null;
   tagsOriginal: string | null;
-  summary: string | null;
   about: string | null;
   ownedByAccount: GetPostsData_posts_sharedPost_space_ownedByAccount_profileSpace_ownedByAccount;
 }
@@ -408,7 +399,6 @@ export interface GetPostsData_posts_sharedPost_space {
   postsCount: number;
   image: string | null;
   tagsOriginal: string | null;
-  summary: string | null;
   about: string | null;
   ownedByAccount: GetPostsData_posts_sharedPost_space_ownedByAccount;
 }
@@ -431,7 +421,6 @@ export interface GetPostsData_posts_sharedPost {
   createdAtTime: any | null;
   createdByAccount: GetPostsData_posts_sharedPost_createdByAccount;
   title: string | null;
-  summary: string | null;
   body: string | null;
   image: string | null;
   link: string | null;
@@ -458,7 +447,6 @@ export interface GetPostsData_posts {
   createdAtTime: any | null;
   createdByAccount: GetPostsData_posts_createdByAccount;
   title: string | null;
-  summary: string | null;
   body: string | null;
   image: string | null;
   link: string | null;

--- a/src/graphql/__generated__/GetProfilesData.ts
+++ b/src/graphql/__generated__/GetProfilesData.ts
@@ -40,7 +40,6 @@ export interface GetProfilesData_accounts_profileSpace {
   postsCount: number;
   image: string | null;
   tagsOriginal: string | null;
-  summary: string | null;
   about: string | null;
   ownedByAccount: GetProfilesData_accounts_profileSpace_ownedByAccount;
 }

--- a/src/graphql/__generated__/GetSpacesData.ts
+++ b/src/graphql/__generated__/GetSpacesData.ts
@@ -47,7 +47,6 @@ export interface GetSpacesData_spaces_ownedByAccount_profileSpace {
   postsCount: number;
   image: string | null;
   tagsOriginal: string | null;
-  summary: string | null;
   about: string | null;
   ownedByAccount: GetSpacesData_spaces_ownedByAccount_profileSpace_ownedByAccount;
 }
@@ -76,7 +75,6 @@ export interface GetSpacesData_spaces {
   postsCount: number;
   image: string | null;
   tagsOriginal: string | null;
-  summary: string | null;
   about: string | null;
   ownedByAccount: GetSpacesData_spaces_ownedByAccount;
 }

--- a/src/graphql/__generated__/PostFragment.ts
+++ b/src/graphql/__generated__/PostFragment.ts
@@ -47,7 +47,6 @@ export interface PostFragment_ownedByAccount_profileSpace {
   postsCount: number;
   image: string | null;
   tagsOriginal: string | null;
-  summary: string | null;
   about: string | null;
   ownedByAccount: PostFragment_ownedByAccount_profileSpace_ownedByAccount;
 }
@@ -97,7 +96,6 @@ export interface PostFragment_space_ownedByAccount_profileSpace {
   postsCount: number;
   image: string | null;
   tagsOriginal: string | null;
-  summary: string | null;
   about: string | null;
   ownedByAccount: PostFragment_space_ownedByAccount_profileSpace_ownedByAccount;
 }
@@ -126,7 +124,6 @@ export interface PostFragment_space {
   postsCount: number;
   image: string | null;
   tagsOriginal: string | null;
-  summary: string | null;
   about: string | null;
   ownedByAccount: PostFragment_space_ownedByAccount;
 }
@@ -148,7 +145,6 @@ export interface PostFragment {
   createdAtTime: any | null;
   createdByAccount: PostFragment_createdByAccount;
   title: string | null;
-  summary: string | null;
   body: string | null;
   image: string | null;
   link: string | null;

--- a/src/graphql/__generated__/PostSimpleFragment.ts
+++ b/src/graphql/__generated__/PostSimpleFragment.ts
@@ -41,7 +41,6 @@ export interface PostSimpleFragment {
   createdAtTime: any | null;
   createdByAccount: PostSimpleFragment_createdByAccount;
   title: string | null;
-  summary: string | null;
   body: string | null;
   image: string | null;
   link: string | null;

--- a/src/graphql/__generated__/ProfileFragment.ts
+++ b/src/graphql/__generated__/ProfileFragment.ts
@@ -40,7 +40,6 @@ export interface ProfileFragment_profileSpace {
   postsCount: number;
   image: string | null;
   tagsOriginal: string | null;
-  summary: string | null;
   about: string | null;
   ownedByAccount: ProfileFragment_profileSpace_ownedByAccount;
 }

--- a/src/graphql/__generated__/SpaceFragment.ts
+++ b/src/graphql/__generated__/SpaceFragment.ts
@@ -45,7 +45,6 @@ export interface SpaceFragment_ownedByAccount_profileSpace {
   postsCount: number;
   image: string | null;
   tagsOriginal: string | null;
-  summary: string | null;
   about: string | null;
   ownedByAccount: SpaceFragment_ownedByAccount_profileSpace_ownedByAccount;
 }
@@ -74,7 +73,6 @@ export interface SpaceFragment {
   postsCount: number;
   image: string | null;
   tagsOriginal: string | null;
-  summary: string | null;
   about: string | null;
   ownedByAccount: SpaceFragment_ownedByAccount;
 }

--- a/src/graphql/__generated__/SpaceSimpleFragment.ts
+++ b/src/graphql/__generated__/SpaceSimpleFragment.ts
@@ -34,7 +34,6 @@ export interface SpaceSimpleFragment {
   postsCount: number;
   image: string | null;
   tagsOriginal: string | null;
-  summary: string | null;
   about: string | null;
   ownedByAccount: SpaceSimpleFragment_ownedByAccount;
 }

--- a/src/graphql/apis/mappers.ts
+++ b/src/graphql/apis/mappers.ts
@@ -62,15 +62,16 @@ export const mapSimpleProfileFragment = ({
 })
 
 export const mapSimpleSpaceFragment = (space: SpaceSimpleFragment): SpaceSimpleFragmentMapped => {
+  const summarizedAbout = summarizeMd(space.about ?? '')
   const getContent = () => ({
     image: space.image ?? '',
     name: space.name ?? '',
     tags: getTokensFromUnifiedString(space.tagsOriginal),
-    summary: space.summary ?? '',
+    summary: summarizedAbout.summary ?? '',
     about: space.about ?? '',
     email: space.email ?? '',
     links: getTokensFromUnifiedString(space.linksOriginal),
-    isShowMore: false,
+    isShowMore: summarizedAbout.isShowMore,
   })
   const isIpfsDataError =
     space.content && !space.name && !space.image && !space.about && !space.email

--- a/src/graphql/client.ts
+++ b/src/graphql/client.ts
@@ -1,6 +1,5 @@
 import { ApolloClient, InMemoryCache, NormalizedCacheObject } from '@apollo/client'
 import { useMemo } from 'react'
-import { isServerSide } from 'src/components/utils'
 import config from 'src/config'
 
 const { enableGraphQl, graphqlUrl } = config
@@ -8,7 +7,7 @@ const { enableGraphQl, graphqlUrl } = config
 let apolloClient: ApolloClient<NormalizedCacheObject>
 
 export function getApolloClient() {
-  return apolloClient || initializeApollo()
+  return apolloClient
 }
 
 const createApolloClient = (graphqlUrl: string): ApolloClient<NormalizedCacheObject> => {
@@ -26,8 +25,6 @@ export const initializeApollo = (initialState: any = null) => {
   if (initialState) {
     _apolloClient.cache.restore(initialState)
   }
-
-  if (isServerSide()) return _apolloClient
 
   if (!apolloClient) apolloClient = _apolloClient
 

--- a/src/graphql/client.ts
+++ b/src/graphql/client.ts
@@ -5,7 +5,11 @@ import config from 'src/config'
 
 const { enableGraphQl, graphqlUrl } = config
 
-export let apolloClient: ApolloClient<NormalizedCacheObject>
+let apolloClient: ApolloClient<NormalizedCacheObject>
+
+export function getApolloClient() {
+  return apolloClient || initializeApollo()
+}
 
 const createApolloClient = (graphqlUrl: string): ApolloClient<NormalizedCacheObject> => {
   return new ApolloClient({

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -65,7 +65,6 @@ export const SPACE_SIMPLE_FRAGMENT = gql`
     postsCount
     image
     tagsOriginal
-    summary
     about
     ownedByAccount {
       id
@@ -82,7 +81,6 @@ export const POST_SIMPLE_FRAGMENT = gql`
       id
     }
     title
-    summary
     body
     image
     link

--- a/src/layout/SideMenuItems.tsx
+++ b/src/layout/SideMenuItems.tsx
@@ -2,7 +2,6 @@ import {
   BookOutlined,
   BugOutlined,
   BulbOutlined,
-  CommentOutlined,
   CompassOutlined,
   GlobalOutlined,
   LineChartOutlined,
@@ -77,11 +76,11 @@ export const DefaultMenu: MenuItem[] = [
     page: ['https://twitter.com/subsocialchain'],
     icon: <SubIcon Icon={FiTwitter} />,
   },
-  {
-    name: 'Official Telegram chat',
-    page: ['https://t.me/Subsocial'],
-    icon: <CommentOutlined />,
-  },
+  // {
+  //   name: 'Official Telegram chat',
+  //   page: ['https://t.me/Subsocial'],
+  //   icon: <CommentOutlined />,
+  // },
   {
     name: 'Subsocial Announcements',
     page: ['https://t.me/SubsocialNetwork'],

--- a/src/rtk/features/posts/postsSlice.ts
+++ b/src/rtk/features/posts/postsSlice.ts
@@ -4,7 +4,7 @@ import { FindPostsQuery } from '@subsocial/api/filters'
 import { getFirstOrUndefined } from '@subsocial/utils'
 import { getPostsData } from 'src/graphql/apis'
 import { PostFragmentMapped, PostFragmentWithParent } from 'src/graphql/apis/types'
-import { apolloClient } from 'src/graphql/client'
+import { getApolloClient } from 'src/graphql/client'
 import {
   createFetchOne,
   createSelectUnknownIds,
@@ -195,7 +195,7 @@ const getPosts = createFetchDataFn<PostState[]>([])({
   },
   squid: async ({ ids, publicOnly }: { ids: string[]; publicOnly?: boolean }) => {
     if (ids.length === 0) return []
-    const posts = await getPostsData(apolloClient, {
+    const posts = await getPostsData(getApolloClient(), {
       where: {
         id_in: ids,
         hidden_not_eq: publicOnly ? true : undefined,

--- a/src/rtk/features/profiles/profilesSlice.ts
+++ b/src/rtk/features/profiles/profilesSlice.ts
@@ -3,7 +3,7 @@ import { SubsocialApi } from '@subsocial/api'
 import { bnsToIds, toSubsocialAddress } from '@subsocial/utils'
 import { getProfilesData } from 'src/graphql/apis'
 import { ProfileFragmentMapped } from 'src/graphql/apis/types'
-import { apolloClient } from 'src/graphql/client'
+import { getApolloClient } from 'src/graphql/client'
 import {
   CommonVisibility,
   createFetchOne,
@@ -77,7 +77,7 @@ const getProfiles = createFetchDataFn<ProfileSpaceIdByAccount[]>([])({
     return spaceIdsByAccouts.filter(x => !!x.id)
   },
   squid: async ({ ids }: { ids: string[] }) => {
-    const profiles = await getProfilesData(apolloClient, { ids })
+    const profiles = await getProfilesData(getApolloClient(), { ids })
     return profiles
   },
 })

--- a/src/rtk/features/reactions/myPostReactionsSlice.ts
+++ b/src/rtk/features/reactions/myPostReactionsSlice.ts
@@ -3,7 +3,7 @@ import { SubsocialApi } from '@subsocial/api'
 import { getFirstOrUndefined, idToBn, isDef, isEmptyArray, isEmptyStr } from '@subsocial/utils'
 import BN from 'bn.js'
 import { getAddressPostsReaction } from 'src/graphql/apis'
-import { apolloClient } from 'src/graphql/client'
+import { getApolloClient } from 'src/graphql/client'
 import {
   decodePrependedIdWithAddress,
   FetchManyArgsWithPrefetch,
@@ -117,7 +117,11 @@ const getMyReactionsByPostIds = createFetchDataFn<FetchManyResult>([])({
     return Array.from(reactionByPostId.values())
   },
   squid: async ({ ids, myAddress }: { ids: string[]; myAddress: string }) => {
-    return getAddressPostsReaction(apolloClient, { address: myAddress, postIds: ids }, idSeparator)
+    return getAddressPostsReaction(
+      getApolloClient(),
+      { address: myAddress, postIds: ids },
+      idSeparator,
+    )
   },
 })
 

--- a/src/rtk/features/spaces/spacesSlice.ts
+++ b/src/rtk/features/spaces/spacesSlice.ts
@@ -4,7 +4,7 @@ import { FindSpacesQuery } from '@subsocial/api/filters'
 import { getFirstOrUndefined } from '@subsocial/utils'
 import { getSpacesData } from 'src/graphql/apis'
 import { SpaceFragmentMapped } from 'src/graphql/apis/types'
-import { apolloClient } from 'src/graphql/client'
+import { getApolloClient } from 'src/graphql/client'
 import {
   createFetchOne,
   FetchManyArgsWithPrefetch,
@@ -145,7 +145,7 @@ const getSpaces = createFetchDataFn<SpaceState[]>([])({
     return entities
   },
   squid: async ({ ids }: { ids: string[] }) => {
-    const spaces = await getSpacesData(apolloClient, { where: { id_in: ids } })
+    const spaces = await getSpacesData(getApolloClient(), { where: { id_in: ids } })
     return spaces.map<SpaceState>(space => ({ ...space, isOverview: true }))
   },
 })

--- a/src/styles/subsocial.scss
+++ b/src/styles/subsocial.scss
@@ -490,6 +490,7 @@ a {
   font-size: $font_normal;
   color: $color_font_normal;
   word-break: break-word;
+  line-height: $line-height-normal;
   // margin: $space_small 0;
   /* white-space: pre-wrap; */
 }

--- a/src/styles/subsocial.scss
+++ b/src/styles/subsocial.scss
@@ -106,6 +106,10 @@ a {
   -moz-text-fill-color: transparent;
 }
 
+.CursorPointer {
+  cursor: pointer !important;
+}
+
 .FontTiny {
   font-size: $font_tiny !important;
 }

--- a/src/types/graphql-global-types.ts
+++ b/src/types/graphql-global-types.ts
@@ -672,6 +672,9 @@ export interface PostWhereInput {
   summary_not_startsWith?: string | null
   summary_endsWith?: string | null
   summary_not_endsWith?: string | null
+  isShowMore_isNull?: boolean | null
+  isShowMore_eq?: boolean | null
+  isShowMore_not_eq?: boolean | null
   meta_isNull?: boolean | null
   meta_eq?: string | null
   meta_not_eq?: string | null
@@ -1117,6 +1120,9 @@ export interface SpaceWhereInput {
   summary_not_startsWith?: string | null
   summary_endsWith?: string | null
   summary_not_endsWith?: string | null
+  isShowMore_isNull?: boolean | null
+  isShowMore_eq?: boolean | null
+  isShowMore_not_eq?: boolean | null
   email_isNull?: boolean | null
   email_eq?: string | null
   email_not_eq?: string | null


### PR DESCRIPTION
# Changes
- Add collapse/expand feature to space desc in preview card, and display full about in space page.
- Add link to the space page for the summarized space desc
- Integrate `isShowMore` for `space` graphql data
- Remove `summary` field from graphql query because that data is now from `summarizeMd(space.about)` and `summarizeMd(post.body)`
- Fix apollo error when getting data from graphql in ssr
- Toggle space description when clicking space desc text
- Remove telegram chat from sidebar
- Change see more in post preview wording

# Question
- Before, in `initializeApollo`, there is a code `if (isServerSide()) return _apolloClient`. Why when you get data from ssr, you don't want to set it to the variable `apolloClient`? Is it okay to remove this line?

