### PR TITLE
Update notifications query

### DIFF
--- a/src/graphql/__generated__/GetNotifications.ts
+++ b/src/graphql/__generated__/GetNotifications.ts
@@ -9,60 +9,55 @@ import { EventName } from "./../../types/graphql-global-types";
 // GraphQL query operation: GetNotifications
 // ====================================================
 
-export interface GetNotifications_accountById_notifications_activity_account {
+export interface GetNotifications_notifications_activity_account {
   __typename: "Account";
   id: string;
 }
 
-export interface GetNotifications_accountById_notifications_activity_post {
+export interface GetNotifications_notifications_activity_post {
   __typename: "Post";
   id: string;
   isComment: boolean;
 }
 
-export interface GetNotifications_accountById_notifications_activity_space {
+export interface GetNotifications_notifications_activity_space {
   __typename: "Space";
   id: string;
 }
 
-export interface GetNotifications_accountById_notifications_activity_followingAccount {
+export interface GetNotifications_notifications_activity_followingAccount {
   __typename: "Account";
   id: string;
 }
 
-export interface GetNotifications_accountById_notifications_activity_reaction {
+export interface GetNotifications_notifications_activity_reaction {
   __typename: "Reaction";
   id: string;
 }
 
-export interface GetNotifications_accountById_notifications_activity {
+export interface GetNotifications_notifications_activity {
   __typename: "Activity";
-  account: GetNotifications_accountById_notifications_activity_account;
+  account: GetNotifications_notifications_activity_account;
   blockNumber: any;
   eventIndex: number;
   event: EventName;
   date: any;
   aggCount: any;
   aggregated: boolean | null;
-  post: GetNotifications_accountById_notifications_activity_post | null;
-  space: GetNotifications_accountById_notifications_activity_space | null;
-  followingAccount: GetNotifications_accountById_notifications_activity_followingAccount | null;
-  reaction: GetNotifications_accountById_notifications_activity_reaction | null;
+  post: GetNotifications_notifications_activity_post | null;
+  space: GetNotifications_notifications_activity_space | null;
+  followingAccount: GetNotifications_notifications_activity_followingAccount | null;
+  reaction: GetNotifications_notifications_activity_reaction | null;
 }
 
-export interface GetNotifications_accountById_notifications {
+export interface GetNotifications_notifications {
   __typename: "Notification";
   id: string;
-  activity: GetNotifications_accountById_notifications_activity;
-}
-
-export interface GetNotifications_accountById {
-  __typename: "Account";
-  notifications: GetNotifications_accountById_notifications[];
+  activity: GetNotifications_notifications_activity;
 }
 
 export interface GetNotifications {
-  accountById: GetNotifications_accountById | null;
+  notifications: GetNotifications_notifications[];
 }
 
 export interface GetNotificationsVariables {

--- a/src/graphql/__generated__/GetPostsData.ts
+++ b/src/graphql/__generated__/GetPostsData.ts
@@ -128,160 +128,9 @@ export interface GetPostsData_posts_space {
   ownedByAccount: GetPostsData_posts_space_ownedByAccount;
 }
 
-export interface GetPostsData_posts_parentPost_createdByAccount {
-  __typename: "Account";
-  id: string;
-}
-
-export interface GetPostsData_posts_parentPost_ownedByAccount_profileSpace_profileSpace {
-  __typename: "Account";
-  followingAccountsCount: number;
-}
-
-export interface GetPostsData_posts_parentPost_ownedByAccount_profileSpace_createdByAccount {
-  __typename: "Account";
-  id: string;
-}
-
-export interface GetPostsData_posts_parentPost_ownedByAccount_profileSpace_ownedByAccount {
-  __typename: "Account";
-  id: string;
-}
-
-export interface GetPostsData_posts_parentPost_ownedByAccount_profileSpace {
-  __typename: "Space";
-  id: string;
-  profileSpace: GetPostsData_posts_parentPost_ownedByAccount_profileSpace_profileSpace | null;
-  canEveryoneCreatePosts: boolean | null;
-  canFollowerCreatePosts: boolean | null;
-  content: string | null;
-  createdAtBlock: any | null;
-  createdAtTime: any | null;
-  createdByAccount: GetPostsData_posts_parentPost_ownedByAccount_profileSpace_createdByAccount;
-  email: string | null;
-  name: string | null;
-  linksOriginal: string | null;
-  hidden: boolean;
-  updatedAtTime: any | null;
-  postsCount: number;
-  image: string | null;
-  tagsOriginal: string | null;
-  about: string | null;
-  ownedByAccount: GetPostsData_posts_parentPost_ownedByAccount_profileSpace_ownedByAccount;
-}
-
-export interface GetPostsData_posts_parentPost_ownedByAccount {
-  __typename: "Account";
-  id: string;
-  followersCount: number;
-  profileSpace: GetPostsData_posts_parentPost_ownedByAccount_profileSpace | null;
-}
-
-export interface GetPostsData_posts_parentPost_space_createdByAccount {
-  __typename: "Account";
-  id: string;
-}
-
-export interface GetPostsData_posts_parentPost_space_ownedByAccount_profileSpace_profileSpace {
-  __typename: "Account";
-  followingAccountsCount: number;
-}
-
-export interface GetPostsData_posts_parentPost_space_ownedByAccount_profileSpace_createdByAccount {
-  __typename: "Account";
-  id: string;
-}
-
-export interface GetPostsData_posts_parentPost_space_ownedByAccount_profileSpace_ownedByAccount {
-  __typename: "Account";
-  id: string;
-}
-
-export interface GetPostsData_posts_parentPost_space_ownedByAccount_profileSpace {
-  __typename: "Space";
-  id: string;
-  profileSpace: GetPostsData_posts_parentPost_space_ownedByAccount_profileSpace_profileSpace | null;
-  canEveryoneCreatePosts: boolean | null;
-  canFollowerCreatePosts: boolean | null;
-  content: string | null;
-  createdAtBlock: any | null;
-  createdAtTime: any | null;
-  createdByAccount: GetPostsData_posts_parentPost_space_ownedByAccount_profileSpace_createdByAccount;
-  email: string | null;
-  name: string | null;
-  linksOriginal: string | null;
-  hidden: boolean;
-  updatedAtTime: any | null;
-  postsCount: number;
-  image: string | null;
-  tagsOriginal: string | null;
-  about: string | null;
-  ownedByAccount: GetPostsData_posts_parentPost_space_ownedByAccount_profileSpace_ownedByAccount;
-}
-
-export interface GetPostsData_posts_parentPost_space_ownedByAccount {
-  __typename: "Account";
-  id: string;
-  followersCount: number;
-  profileSpace: GetPostsData_posts_parentPost_space_ownedByAccount_profileSpace | null;
-}
-
-export interface GetPostsData_posts_parentPost_space {
-  __typename: "Space";
-  id: string;
-  canEveryoneCreatePosts: boolean | null;
-  canFollowerCreatePosts: boolean | null;
-  content: string | null;
-  createdAtBlock: any | null;
-  createdAtTime: any | null;
-  createdByAccount: GetPostsData_posts_parentPost_space_createdByAccount;
-  email: string | null;
-  name: string | null;
-  linksOriginal: string | null;
-  hidden: boolean;
-  updatedAtTime: any | null;
-  postsCount: number;
-  image: string | null;
-  tagsOriginal: string | null;
-  about: string | null;
-  ownedByAccount: GetPostsData_posts_parentPost_space_ownedByAccount;
-}
-
-export interface GetPostsData_posts_parentPost_parentPost {
+export interface GetPostsData_posts_rootPost {
   __typename: "Post";
   id: string;
-}
-
-export interface GetPostsData_posts_parentPost_sharedPost {
-  __typename: "Post";
-  id: string;
-}
-
-export interface GetPostsData_posts_parentPost {
-  __typename: "Post";
-  id: string;
-  content: string | null;
-  createdAtBlock: any | null;
-  createdAtTime: any | null;
-  createdByAccount: GetPostsData_posts_parentPost_createdByAccount;
-  title: string | null;
-  body: string | null;
-  image: string | null;
-  link: string | null;
-  downvotesCount: number;
-  hidden: boolean;
-  isComment: boolean;
-  kind: PostKind | null;
-  repliesCount: number;
-  sharesCount: number;
-  upvotesCount: number;
-  updatedAtTime: any | null;
-  canonical: string | null;
-  tagsOriginal: string | null;
-  ownedByAccount: GetPostsData_posts_parentPost_ownedByAccount;
-  space: GetPostsData_posts_parentPost_space | null;
-  parentPost: GetPostsData_posts_parentPost_parentPost | null;
-  sharedPost: GetPostsData_posts_parentPost_sharedPost | null;
 }
 
 export interface GetPostsData_posts_sharedPost_createdByAccount {
@@ -403,7 +252,7 @@ export interface GetPostsData_posts_sharedPost_space {
   ownedByAccount: GetPostsData_posts_sharedPost_space_ownedByAccount;
 }
 
-export interface GetPostsData_posts_sharedPost_parentPost {
+export interface GetPostsData_posts_sharedPost_rootPost {
   __typename: "Post";
   id: string;
 }
@@ -436,8 +285,164 @@ export interface GetPostsData_posts_sharedPost {
   tagsOriginal: string | null;
   ownedByAccount: GetPostsData_posts_sharedPost_ownedByAccount;
   space: GetPostsData_posts_sharedPost_space | null;
-  parentPost: GetPostsData_posts_sharedPost_parentPost | null;
+  rootPost: GetPostsData_posts_sharedPost_rootPost | null;
   sharedPost: GetPostsData_posts_sharedPost_sharedPost | null;
+}
+
+export interface GetPostsData_posts_parentPost_createdByAccount {
+  __typename: "Account";
+  id: string;
+}
+
+export interface GetPostsData_posts_parentPost_ownedByAccount_profileSpace_profileSpace {
+  __typename: "Account";
+  followingAccountsCount: number;
+}
+
+export interface GetPostsData_posts_parentPost_ownedByAccount_profileSpace_createdByAccount {
+  __typename: "Account";
+  id: string;
+}
+
+export interface GetPostsData_posts_parentPost_ownedByAccount_profileSpace_ownedByAccount {
+  __typename: "Account";
+  id: string;
+}
+
+export interface GetPostsData_posts_parentPost_ownedByAccount_profileSpace {
+  __typename: "Space";
+  id: string;
+  profileSpace: GetPostsData_posts_parentPost_ownedByAccount_profileSpace_profileSpace | null;
+  canEveryoneCreatePosts: boolean | null;
+  canFollowerCreatePosts: boolean | null;
+  content: string | null;
+  createdAtBlock: any | null;
+  createdAtTime: any | null;
+  createdByAccount: GetPostsData_posts_parentPost_ownedByAccount_profileSpace_createdByAccount;
+  email: string | null;
+  name: string | null;
+  linksOriginal: string | null;
+  hidden: boolean;
+  updatedAtTime: any | null;
+  postsCount: number;
+  image: string | null;
+  tagsOriginal: string | null;
+  about: string | null;
+  ownedByAccount: GetPostsData_posts_parentPost_ownedByAccount_profileSpace_ownedByAccount;
+}
+
+export interface GetPostsData_posts_parentPost_ownedByAccount {
+  __typename: "Account";
+  id: string;
+  followersCount: number;
+  profileSpace: GetPostsData_posts_parentPost_ownedByAccount_profileSpace | null;
+}
+
+export interface GetPostsData_posts_parentPost_space_createdByAccount {
+  __typename: "Account";
+  id: string;
+}
+
+export interface GetPostsData_posts_parentPost_space_ownedByAccount_profileSpace_profileSpace {
+  __typename: "Account";
+  followingAccountsCount: number;
+}
+
+export interface GetPostsData_posts_parentPost_space_ownedByAccount_profileSpace_createdByAccount {
+  __typename: "Account";
+  id: string;
+}
+
+export interface GetPostsData_posts_parentPost_space_ownedByAccount_profileSpace_ownedByAccount {
+  __typename: "Account";
+  id: string;
+}
+
+export interface GetPostsData_posts_parentPost_space_ownedByAccount_profileSpace {
+  __typename: "Space";
+  id: string;
+  profileSpace: GetPostsData_posts_parentPost_space_ownedByAccount_profileSpace_profileSpace | null;
+  canEveryoneCreatePosts: boolean | null;
+  canFollowerCreatePosts: boolean | null;
+  content: string | null;
+  createdAtBlock: any | null;
+  createdAtTime: any | null;
+  createdByAccount: GetPostsData_posts_parentPost_space_ownedByAccount_profileSpace_createdByAccount;
+  email: string | null;
+  name: string | null;
+  linksOriginal: string | null;
+  hidden: boolean;
+  updatedAtTime: any | null;
+  postsCount: number;
+  image: string | null;
+  tagsOriginal: string | null;
+  about: string | null;
+  ownedByAccount: GetPostsData_posts_parentPost_space_ownedByAccount_profileSpace_ownedByAccount;
+}
+
+export interface GetPostsData_posts_parentPost_space_ownedByAccount {
+  __typename: "Account";
+  id: string;
+  followersCount: number;
+  profileSpace: GetPostsData_posts_parentPost_space_ownedByAccount_profileSpace | null;
+}
+
+export interface GetPostsData_posts_parentPost_space {
+  __typename: "Space";
+  id: string;
+  canEveryoneCreatePosts: boolean | null;
+  canFollowerCreatePosts: boolean | null;
+  content: string | null;
+  createdAtBlock: any | null;
+  createdAtTime: any | null;
+  createdByAccount: GetPostsData_posts_parentPost_space_createdByAccount;
+  email: string | null;
+  name: string | null;
+  linksOriginal: string | null;
+  hidden: boolean;
+  updatedAtTime: any | null;
+  postsCount: number;
+  image: string | null;
+  tagsOriginal: string | null;
+  about: string | null;
+  ownedByAccount: GetPostsData_posts_parentPost_space_ownedByAccount;
+}
+
+export interface GetPostsData_posts_parentPost_rootPost {
+  __typename: "Post";
+  id: string;
+}
+
+export interface GetPostsData_posts_parentPost_sharedPost {
+  __typename: "Post";
+  id: string;
+}
+
+export interface GetPostsData_posts_parentPost {
+  __typename: "Post";
+  content: string | null;
+  createdAtBlock: any | null;
+  createdAtTime: any | null;
+  createdByAccount: GetPostsData_posts_parentPost_createdByAccount;
+  title: string | null;
+  body: string | null;
+  image: string | null;
+  link: string | null;
+  downvotesCount: number;
+  hidden: boolean;
+  id: string;
+  isComment: boolean;
+  kind: PostKind | null;
+  repliesCount: number;
+  sharesCount: number;
+  upvotesCount: number;
+  updatedAtTime: any | null;
+  canonical: string | null;
+  tagsOriginal: string | null;
+  ownedByAccount: GetPostsData_posts_parentPost_ownedByAccount;
+  space: GetPostsData_posts_parentPost_space | null;
+  rootPost: GetPostsData_posts_parentPost_rootPost | null;
+  sharedPost: GetPostsData_posts_parentPost_sharedPost | null;
 }
 
 export interface GetPostsData_posts {
@@ -463,8 +468,9 @@ export interface GetPostsData_posts {
   tagsOriginal: string | null;
   ownedByAccount: GetPostsData_posts_ownedByAccount;
   space: GetPostsData_posts_space | null;
-  parentPost: GetPostsData_posts_parentPost | null;
+  rootPost: GetPostsData_posts_rootPost | null;
   sharedPost: GetPostsData_posts_sharedPost | null;
+  parentPost: GetPostsData_posts_parentPost | null;
 }
 
 export interface GetPostsData {

--- a/src/graphql/__generated__/PostFragment.ts
+++ b/src/graphql/__generated__/PostFragment.ts
@@ -128,7 +128,7 @@ export interface PostFragment_space {
   ownedByAccount: PostFragment_space_ownedByAccount;
 }
 
-export interface PostFragment_parentPost {
+export interface PostFragment_rootPost {
   __typename: "Post";
   id: string;
 }
@@ -161,6 +161,6 @@ export interface PostFragment {
   tagsOriginal: string | null;
   ownedByAccount: PostFragment_ownedByAccount;
   space: PostFragment_space | null;
-  parentPost: PostFragment_parentPost | null;
+  rootPost: PostFragment_rootPost | null;
   sharedPost: PostFragment_sharedPost | null;
 }

--- a/src/graphql/__generated__/PostSimpleFragment.ts
+++ b/src/graphql/__generated__/PostSimpleFragment.ts
@@ -24,7 +24,7 @@ export interface PostSimpleFragment_space {
   id: string;
 }
 
-export interface PostSimpleFragment_parentPost {
+export interface PostSimpleFragment_rootPost {
   __typename: "Post";
   id: string;
 }
@@ -57,6 +57,6 @@ export interface PostSimpleFragment {
   tagsOriginal: string | null;
   ownedByAccount: PostSimpleFragment_ownedByAccount;
   space: PostSimpleFragment_space | null;
-  parentPost: PostSimpleFragment_parentPost | null;
+  rootPost: PostSimpleFragment_rootPost | null;
   sharedPost: PostSimpleFragment_sharedPost | null;
 }

--- a/src/graphql/apis/index.ts
+++ b/src/graphql/apis/index.ts
@@ -227,7 +227,7 @@ export async function getAllNotifications(client: GqlClient, variables: GetNotif
     variables,
   })
   return (
-    notifications.data.accountById?.notifications.map(({ activity }) => {
+    notifications.data?.notifications.map(({ activity }) => {
       const isComment = activity.post?.isComment
       return mapActivityQueryResult(activity, {
         followingId: activity.followingAccount?.id,

--- a/src/graphql/apis/mappers.ts
+++ b/src/graphql/apis/mappers.ts
@@ -124,7 +124,7 @@ export const mapSimplePostFragment = (post: PostSimpleFragment): PostSimpleFragm
     spaceId: post.space?.id,
     isUpdated: !!post.updatedAtTime,
     originalPostId: post.sharedPost?.id,
-    rootPostId: post.parentPost?.id,
+    rootPostId: post.rootPost?.id,
     ipfsContent: isIpfsDataError ? undefined : getContent(),
   }
 }

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -593,7 +593,20 @@ export const GET_NOTIFICATIONS_COUNT = gql`
     notificationsConnection(
       orderBy: id_ASC
       where: {
-        account: { id_eq: $address }
+        AND: {
+          account: { id_eq: $address }
+          OR: {
+            activity: {
+              post: {
+                OR: [
+                  { OR: { ownedByAccount: { id_eq: $address } } }
+                  { OR: { rootPost: { ownedByAccount: { id_eq: $address } } } }
+                  { OR: { parentPost: { ownedByAccount: { id_eq: $address } } } }
+                ]
+              }
+            }
+          }
+        }
         activity: { aggregated_eq: true, account: { id_not_eq: $address }, date_gt: $afterDate }
       }
     ) {
@@ -607,28 +620,21 @@ export const GET_NOTIFICATIONS = gql`
   query GetNotifications($address: String!, $offset: Int = 0, $limit: Int!) {
     notifications(
       where: {
-        activity: {
-          aggregated_eq: true
-          account: { id_not_eq: $address }
-          AND: {
-            OR: [
-              { OR: { space: { ownedByAccount: { id_eq: $address } } } }
-              { OR: { followingAccount: { id_eq: $address } } }
-              { OR: { reaction: { post: { ownedByAccount: { id_eq: $address } } } } }
-              {
-                OR: {
-                  post: {
-                    OR: [
-                      { OR: { ownedByAccount: { id_eq: $address } } }
-                      { OR: { rootPost: { ownedByAccount: { id_eq: $address } } } }
-                      { OR: { parentPost: { ownedByAccount: { id_eq: $address } } } }
-                    ]
-                  }
-                }
+        AND: {
+          account: { id_eq: $address }
+          OR: {
+            activity: {
+              post: {
+                OR: [
+                  { OR: { ownedByAccount: { id_eq: $address } } }
+                  { OR: { rootPost: { ownedByAccount: { id_eq: $address } } } }
+                  { OR: { parentPost: { ownedByAccount: { id_eq: $address } } } }
+                ]
               }
-            ]
+            }
           }
         }
+        activity: { aggregated_eq: true, account: { id_not_eq: $address } }
       }
       limit: $limit
       offset: $offset


### PR DESCRIPTION
# Problem
Previously, its using `accountById` to get notification for specific address.
Using this is much more easier and readable than the new one. But, there are a problem in squid for that specific query,
where many notifications are not displayed there.

# Solution
Until the `accountById` query is fixed, I propose using another query, that is `notifications` query with additional filter