### PR TITLE
Fix twitter card preview

### DIFF
--- a/src/graphql/ApolloProvider.tsx
+++ b/src/graphql/ApolloProvider.tsx
@@ -9,7 +9,7 @@ import config from 'src/config'
 import { useApollo } from './client'
 
 type ApolloProviderProps = {
-  initialApolloState: NormalizedCacheObject
+  initialApolloState?: NormalizedCacheObject
 }
 
 export type GqlClient = ApolloClient<object>

--- a/src/graphql/client.ts
+++ b/src/graphql/client.ts
@@ -31,7 +31,7 @@ export const initializeApollo = (initialState: any = null) => {
   return _apolloClient
 }
 
-export const useApollo = (initialState: NormalizedCacheObject) => {
+export const useApollo = (initialState?: NormalizedCacheObject) => {
   const store = useMemo(() => initializeApollo(initialState), [initialState])
   return store
 }

--- a/src/rtk/app/nextHelpers.tsx
+++ b/src/rtk/app/nextHelpers.tsx
@@ -32,7 +32,6 @@ export const getInitialPropsWithRedux = async <ResultProps extends {} = {}>(
 
     return {
       initialReduxState: reduxStore.getState(),
-      initialApolloState: apolloClient?.cache.extract(),
       ...resultProps,
     }
   })


### PR DESCRIPTION
# Problem
Currently, twitter card preview for polkaverse doesn't appear. After some checking, I found out that it's because of html too large. Its the response from [twitter card validator](https://cards-dev.twitter.com/validator).
To check, I use curl to the polkaverse article, and found out that the initialApolloState bloats the html, making the html size into ~5mb
Curl command used:
```
curl https://polkaverse.com/@tnathanielk/how-i-won-18-000-in-a-hackathon-37274 > test3.html
```

# Solution
Remove `initialApolloState` cache in the `getInitialProps` data.

This can work because the one that fetches using apollo client in server are in `getInitialPropsWithRedux`, and the only one that's using it directly is in `HomePage`, but its sending back the resulting data in other props too. Other parts are using it indirectly from fetches in redux. But this one doesn't have a problem too because the data are put into redux and the ones used are the ones in redux.

The cache also works indirectly, for example if you want to query and don't have the data in cache, it will still fetch the original data. So I think the worst thing that can happen by not sending apollo cache from server is just additional fetches in client.

From what I check, it seems that cache data is not used if we use `client.query`, so it's actually useless too. I think it will be used if we use `useQuery` instead

# Result
I checked using curl, for the deployed staging for this branch (fix), and the production (usual) after accessing `/@subsocial`, because its one of the page that's fetching post from server side
fix: `curl https://fix-twitter-card.subsocial.network/@tnathanielk/how-i-won-18-000-in-a-hackathon-37274 > test-fix.html`
usual: `curl https://test.subsocial.network/@tnathanielk/how-i-won-18-000-in-a-hackathon-37274 > test-usual.html`

note: after visiting more space pages, the usual one increases to 362kb while the fixed one still 33kb

![image](https://user-images.githubusercontent.com/53143942/214361960-a7902a9f-526b-4432-ae99-99f470b3e0cf.png)
![image](https://user-images.githubusercontent.com/53143942/214362417-566017d3-96d5-4363-adcb-1af091130498.png)
