### PR TITLE
Fix bug with notification regarding shared post

### DIFF
--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -597,11 +597,13 @@ export const GET_NOTIFICATIONS_COUNT = gql`
           account: { id_eq: $address }
           OR: {
             activity: {
+              event_eq: CommentCreated
               post: {
                 OR: [
                   { OR: { ownedByAccount: { id_eq: $address } } }
                   { OR: { rootPost: { ownedByAccount: { id_eq: $address } } } }
                   { OR: { parentPost: { ownedByAccount: { id_eq: $address } } } }
+                  { OR: { rootPost: { space: { ownedByAccount: { id_eq: $address } } } } }
                 ]
               }
             }
@@ -624,6 +626,7 @@ export const GET_NOTIFICATIONS = gql`
           account: { id_eq: $address }
           OR: {
             activity: {
+              event_eq: CommentCreated
               post: {
                 OR: [
                   { OR: { ownedByAccount: { id_eq: $address } } }


### PR DESCRIPTION
# Problem
The additional condition for notification previously will make 1 shared post event shows multiple times in the notification of the post creator.

# Solution
Put additional condition to the post creator condition so it only affects CommentCreated event