### PR TITLE
Change Query Logic for Account Activities (Space, Comments, and Posts)

### DIFF
--- a/src/components/posts/view-post/PostPreview.tsx
+++ b/src/components/posts/view-post/PostPreview.tsx
@@ -28,13 +28,13 @@ export function PostPreview(props: PreviewProps) {
   const space = externalSpace || globalSpace
   const isUnlisted = useIsUnlistedPost({ post, space: space?.struct })
 
-  if (!space || isUnlisted) return null
+  if (isUnlisted) return null
 
   log.debug('Render a post w/ id:', post.id)
 
   return (
     <Segment className='DfPostPreview'>
-      <HiddenPostAlert post={post} space={space.struct} preview />
+      <HiddenPostAlert post={post} space={space?.struct} preview />
       {isSharedPost ? (
         <SharedPreview space={space} {...props} />
       ) : (

--- a/src/graphql/__generated__/GetActivityCounts.ts
+++ b/src/graphql/__generated__/GetActivityCounts.ts
@@ -28,17 +28,12 @@ export interface GetActivityCounts_comments {
 }
 
 export interface GetActivityCounts_reactions {
-  __typename: "ReactionsConnection";
+  __typename: "ActivitiesConnection";
   totalCount: number;
 }
 
-export interface GetActivityCounts_spaceFollows {
-  __typename: "SpaceFollowersConnection";
-  totalCount: number;
-}
-
-export interface GetActivityCounts_accountFollows {
-  __typename: "AccountFollowersConnection";
+export interface GetActivityCounts_follows {
+  __typename: "ActivitiesConnection";
   totalCount: number;
 }
 
@@ -48,8 +43,7 @@ export interface GetActivityCounts {
   spaces: GetActivityCounts_spaces;
   comments: GetActivityCounts_comments;
   reactions: GetActivityCounts_reactions;
-  spaceFollows: GetActivityCounts_spaceFollows;
-  accountFollows: GetActivityCounts_accountFollows;
+  follows: GetActivityCounts_follows;
 }
 
 export interface GetActivityCountsVariables {

--- a/src/graphql/__generated__/GetActivityCounts.ts
+++ b/src/graphql/__generated__/GetActivityCounts.ts
@@ -13,27 +13,32 @@ export interface GetActivityCounts_activities {
 }
 
 export interface GetActivityCounts_posts {
-  __typename: "ActivitiesConnection";
+  __typename: "PostsConnection";
   totalCount: number;
 }
 
 export interface GetActivityCounts_spaces {
-  __typename: "ActivitiesConnection";
+  __typename: "SpacesConnection";
   totalCount: number;
 }
 
 export interface GetActivityCounts_comments {
-  __typename: "ActivitiesConnection";
+  __typename: "PostsConnection";
   totalCount: number;
 }
 
 export interface GetActivityCounts_reactions {
-  __typename: "ActivitiesConnection";
+  __typename: "ReactionsConnection";
   totalCount: number;
 }
 
-export interface GetActivityCounts_follows {
-  __typename: "ActivitiesConnection";
+export interface GetActivityCounts_spaceFollows {
+  __typename: "SpaceFollowersConnection";
+  totalCount: number;
+}
+
+export interface GetActivityCounts_accountFollows {
+  __typename: "AccountFollowersConnection";
   totalCount: number;
 }
 
@@ -43,7 +48,8 @@ export interface GetActivityCounts {
   spaces: GetActivityCounts_spaces;
   comments: GetActivityCounts_comments;
   reactions: GetActivityCounts_reactions;
-  follows: GetActivityCounts_follows;
+  spaceFollows: GetActivityCounts_spaceFollows;
+  accountFollows: GetActivityCounts_accountFollows;
 }
 
 export interface GetActivityCountsVariables {

--- a/src/graphql/__generated__/GetCommentActivities.ts
+++ b/src/graphql/__generated__/GetCommentActivities.ts
@@ -7,19 +7,14 @@
 // GraphQL query operation: GetCommentActivities
 // ====================================================
 
-export interface GetCommentActivities_accountById_activities_post {
+export interface GetCommentActivities_accountById_posts {
   __typename: "Post";
   id: string;
 }
 
-export interface GetCommentActivities_accountById_activities {
-  __typename: "Activity";
-  post: GetCommentActivities_accountById_activities_post | null;
-}
-
 export interface GetCommentActivities_accountById {
   __typename: "Account";
-  activities: GetCommentActivities_accountById_activities[];
+  posts: GetCommentActivities_accountById_posts[];
 }
 
 export interface GetCommentActivities {

--- a/src/graphql/__generated__/GetPostActivities.ts
+++ b/src/graphql/__generated__/GetPostActivities.ts
@@ -7,19 +7,14 @@
 // GraphQL query operation: GetPostActivities
 // ====================================================
 
-export interface GetPostActivities_accountById_activities_post {
+export interface GetPostActivities_accountById_posts {
   __typename: "Post";
   id: string;
 }
 
-export interface GetPostActivities_accountById_activities {
-  __typename: "Activity";
-  post: GetPostActivities_accountById_activities_post | null;
-}
-
 export interface GetPostActivities_accountById {
   __typename: "Account";
-  activities: GetPostActivities_accountById_activities[];
+  posts: GetPostActivities_accountById_posts[];
 }
 
 export interface GetPostActivities {

--- a/src/graphql/__generated__/GetSpaceActivities.ts
+++ b/src/graphql/__generated__/GetSpaceActivities.ts
@@ -7,19 +7,14 @@
 // GraphQL query operation: GetSpaceActivities
 // ====================================================
 
-export interface GetSpaceActivities_accountById_activities_space {
+export interface GetSpaceActivities_accountById_spacesOwned {
   __typename: "Space";
   id: string;
 }
 
-export interface GetSpaceActivities_accountById_activities {
-  __typename: "Activity";
-  space: GetSpaceActivities_accountById_activities_space | null;
-}
-
 export interface GetSpaceActivities_accountById {
   __typename: "Account";
-  activities: GetSpaceActivities_accountById_activities[];
+  spacesOwned: GetSpaceActivities_accountById_spacesOwned[];
 }
 
 export interface GetSpaceActivities {

--- a/src/graphql/apis/index.ts
+++ b/src/graphql/apis/index.ts
@@ -97,11 +97,11 @@ export async function getActivityCounts(
     variables,
   })
 
-  const { activities, comments, accountFollows, spaceFollows, posts, reactions, spaces } = res.data
+  const { activities, comments, follows, posts, reactions, spaces } = res.data
   return {
     activitiesCount: activities.totalCount,
     commentsCount: comments.totalCount,
-    followsCount: (spaceFollows.totalCount || 0) + (accountFollows.totalCount || 0),
+    followsCount: follows.totalCount,
     postsCount: posts.totalCount,
     reactionsCount: reactions.totalCount,
     spacesCount: spaces.totalCount,

--- a/src/graphql/apis/index.ts
+++ b/src/graphql/apis/index.ts
@@ -183,8 +183,8 @@ export async function getPostActivities(client: GqlClient, variables: GetPostAct
     variables,
   })
   const postIds: string[] = []
-  activities.data.accountById?.activities.forEach(activity => {
-    const postId = activity.post?.id
+  activities.data.accountById?.posts.forEach(post => {
+    const postId = post?.id
     if (postId) {
       postIds.push(postId)
     }

--- a/src/graphql/apis/index.ts
+++ b/src/graphql/apis/index.ts
@@ -94,11 +94,11 @@ export async function getActivityCounts(
     variables,
   })
 
-  const { activities, comments, follows, posts, reactions, spaces } = res.data
+  const { activities, comments, accountFollows, spaceFollows, posts, reactions, spaces } = res.data
   return {
     activitiesCount: activities.totalCount,
     commentsCount: comments.totalCount,
-    followsCount: follows.totalCount,
+    followsCount: (spaceFollows.totalCount || 0) + (accountFollows.totalCount || 0),
     postsCount: posts.totalCount,
     reactionsCount: reactions.totalCount,
     spacesCount: spaces.totalCount,

--- a/src/graphql/apis/index.ts
+++ b/src/graphql/apis/index.ts
@@ -201,8 +201,8 @@ export async function getCommentActivities(
     variables,
   })
   const commentIds: string[] = []
-  activities.data.accountById?.activities.forEach(activity => {
-    const commentId = activity.post?.id
+  activities.data.accountById?.posts.forEach(post => {
+    const commentId = post?.id
     if (commentId) {
       commentIds.push(commentId)
     }

--- a/src/graphql/apis/index.ts
+++ b/src/graphql/apis/index.ts
@@ -39,7 +39,10 @@ import {
   GetReactionActivities,
   GetReactionActivitiesVariables,
 } from '../__generated__/GetReactionActivities'
-import { GetSpaceActivitiesVariables } from '../__generated__/GetSpaceActivities'
+import {
+  GetSpaceActivities,
+  GetSpaceActivitiesVariables,
+} from '../__generated__/GetSpaceActivities'
 import { GetSpacesData, GetSpacesDataVariables } from '../__generated__/GetSpacesData'
 import {
   mapActivityQueryResult,
@@ -163,13 +166,13 @@ export async function getSpaceActivities(
   client: GqlClient,
   variables: GetSpaceActivitiesVariables,
 ) {
-  const activities = await client.query<GetFollowActivities, GetFollowActivitiesVariables>({
+  const activities = await client.query<GetSpaceActivities, GetSpaceActivitiesVariables>({
     query: q.GET_SPACE_ACTIVITIES,
     variables,
   })
   const spaceIds: string[] = []
-  activities.data.accountById?.activities.forEach(activity => {
-    const spaceId = activity.space?.id
+  activities.data.accountById?.spacesOwned.forEach(space => {
+    const spaceId = space?.id
     if (spaceId) {
       spaceIds.push(spaceId)
     }

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -519,15 +519,8 @@ export const GET_REACTION_ACTIVITIES = gql`
 export const GET_SPACE_ACTIVITIES = gql`
   query GetSpaceActivities($address: String!, $offset: Int = 0, $limit: Int!) {
     accountById(id: $address) {
-      activities(
-        where: { event_in: [SpaceCreated] }
-        limit: $limit
-        offset: $offset
-        orderBy: date_DESC
-      ) {
-        space {
-          id
-        }
+      spacesOwned(limit: $limit, offset: $offset, orderBy: createdAtTime_DESC) {
+        id
       }
     }
   }

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -411,7 +411,7 @@ export const GET_ACTIVITY_COUNTS = gql`
     }
     comments: postsConnection(
       orderBy: id_ASC
-      where: { ownedByAccount: { id_eq: $address }, isComment_eq: true }
+      where: { ownedByAccount: { id_eq: $address }, isComment_eq: true, hidden_eq: false }
     ) {
       totalCount
     }
@@ -551,15 +551,13 @@ export const GET_POST_ACTIVITIES = gql`
 export const GET_COMMENT_ACTIVITIES = gql`
   query GetCommentActivities($address: String!, $offset: Int = 0, $limit: Int!) {
     accountById(id: $address) {
-      activities(
-        where: { event_in: [CommentCreated, CommentReplyCreated, CommentShared] }
+      posts(
         limit: $limit
         offset: $offset
-        orderBy: date_DESC
+        orderBy: createdAtTime_DESC
+        where: { isComment_eq: true, hidden_eq: false }
       ) {
-        post {
-          id
-        }
+        id
       }
     }
   }

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -533,18 +533,17 @@ export const GET_SPACE_ACTIVITIES = gql`
   }
 `
 
+// TODO: take hidden true? because content is null if hidden true
 export const GET_POST_ACTIVITIES = gql`
   query GetPostActivities($address: String!, $offset: Int = 0, $limit: Int!) {
     accountById(id: $address) {
-      activities(
-        where: { event_in: [PostCreated] }
+      posts(
         limit: $limit
         offset: $offset
-        orderBy: date_DESC
+        orderBy: createdAtTime_DESC
+        where: { isComment_eq: false }
       ) {
-        post {
-          id
-        }
+        id
       }
     }
   }

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -400,48 +400,33 @@ export const GET_ACTIVITY_COUNTS = gql`
     ) {
       totalCount
     }
-    posts: activitiesConnection(
+    posts: postsConnection(
       orderBy: id_ASC
-      where: {
-        account: { id_eq: $address }
-        event_in: [PostCreated]
-        post: { isComment_eq: false }
-      }
+      where: { ownedByAccount: { id_eq: $address }, isComment_eq: false }
     ) {
       totalCount
     }
-    spaces: activitiesConnection(
+    spaces: spacesConnection(orderBy: id_ASC, where: { ownedByAccount: { id_eq: $address } }) {
+      totalCount
+    }
+    comments: postsConnection(
       orderBy: id_ASC
-      where: { account: { id_eq: $address }, event_in: [SpaceCreated] }
+      where: { ownedByAccount: { id_eq: $address }, isComment_eq: true }
     ) {
       totalCount
     }
-    comments: activitiesConnection(
+    reactions: reactionsConnection(orderBy: id_ASC, where: { account: { id_eq: $address } }) {
+      totalCount
+    }
+    spaceFollows: spaceFollowersConnection(
       orderBy: id_ASC
-      where: {
-        account: { id_eq: $address }
-        event_in: [
-          CommentCreated
-          CommentShared
-          CommentReplyCreated
-          CommentReplyShared
-          PostCreated
-          PostShared
-        ]
-        post: { isComment_eq: true }
-      }
+      where: { followerAccount: { id_eq: $address } }
     ) {
       totalCount
     }
-    reactions: activitiesConnection(
+    accountFollows: accountFollowersConnection(
       orderBy: id_ASC
-      where: { account: { id_eq: $address }, event_in: [PostReactionCreated] }
-    ) {
-      totalCount
-    }
-    follows: activitiesConnection(
-      orderBy: id_ASC
-      where: { account: { id_eq: $address }, event_in: [AccountFollowed, SpaceFollowed] }
+      where: { followerAccount: { id_eq: $address } }
     ) {
       totalCount
     }

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -402,7 +402,7 @@ export const GET_ACTIVITY_COUNTS = gql`
     }
     posts: postsConnection(
       orderBy: id_ASC
-      where: { ownedByAccount: { id_eq: $address }, isComment_eq: false }
+      where: { ownedByAccount: { id_eq: $address }, isComment_eq: false, hidden_eq: false }
     ) {
       totalCount
     }
@@ -533,7 +533,6 @@ export const GET_SPACE_ACTIVITIES = gql`
   }
 `
 
-// TODO: take hidden true? because content is null if hidden true
 export const GET_POST_ACTIVITIES = gql`
   query GetPostActivities($address: String!, $offset: Int = 0, $limit: Int!) {
     accountById(id: $address) {
@@ -541,7 +540,7 @@ export const GET_POST_ACTIVITIES = gql`
         limit: $limit
         offset: $offset
         orderBy: createdAtTime_DESC
-        where: { isComment_eq: false }
+        where: { isComment_eq: false, hidden_eq: false }
       ) {
         id
       }

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -415,18 +415,15 @@ export const GET_ACTIVITY_COUNTS = gql`
     ) {
       totalCount
     }
-    reactions: reactionsConnection(orderBy: id_ASC, where: { account: { id_eq: $address } }) {
-      totalCount
-    }
-    spaceFollows: spaceFollowersConnection(
+    reactions: activitiesConnection(
       orderBy: id_ASC
-      where: { followerAccount: { id_eq: $address } }
+      where: { account: { id_eq: $address }, event_in: [PostReactionCreated] }
     ) {
       totalCount
     }
-    accountFollows: accountFollowersConnection(
+    follows: activitiesConnection(
       orderBy: id_ASC
-      where: { followerAccount: { id_eq: $address } }
+      where: { account: { id_eq: $address }, event_in: [AccountFollowed, SpaceFollowed] }
     ) {
       totalCount
     }

--- a/src/types/graphql-global-types.ts
+++ b/src/types/graphql-global-types.ts
@@ -726,6 +726,25 @@ export interface PostWhereInput {
   format_not_startsWith?: string | null
   format_endsWith?: string | null
   format_not_endsWith?: string | null
+  tweetId_isNull?: boolean | null
+  tweetId_eq?: string | null
+  tweetId_not_eq?: string | null
+  tweetId_gt?: string | null
+  tweetId_gte?: string | null
+  tweetId_lt?: string | null
+  tweetId_lte?: string | null
+  tweetId_in?: string[] | null
+  tweetId_not_in?: string[] | null
+  tweetId_contains?: string | null
+  tweetId_not_contains?: string | null
+  tweetId_containsInsensitive?: string | null
+  tweetId_not_containsInsensitive?: string | null
+  tweetId_startsWith?: string | null
+  tweetId_not_startsWith?: string | null
+  tweetId_endsWith?: string | null
+  tweetId_not_endsWith?: string | null
+  tweetDetails_isNull?: boolean | null
+  tweetDetails?: TweetDetailsWhereInput | null
   proposalIndex_isNull?: boolean | null
   proposalIndex_eq?: number | null
   proposalIndex_not_eq?: number | null
@@ -1174,6 +1193,23 @@ export interface SpaceWhereInput {
   linksOriginal_not_startsWith?: string | null
   linksOriginal_endsWith?: string | null
   linksOriginal_not_endsWith?: string | null
+  interestsOriginal_isNull?: boolean | null
+  interestsOriginal_eq?: string | null
+  interestsOriginal_not_eq?: string | null
+  interestsOriginal_gt?: string | null
+  interestsOriginal_gte?: string | null
+  interestsOriginal_lt?: string | null
+  interestsOriginal_lte?: string | null
+  interestsOriginal_in?: string[] | null
+  interestsOriginal_not_in?: string[] | null
+  interestsOriginal_contains?: string | null
+  interestsOriginal_not_contains?: string | null
+  interestsOriginal_containsInsensitive?: string | null
+  interestsOriginal_not_containsInsensitive?: string | null
+  interestsOriginal_startsWith?: string | null
+  interestsOriginal_not_startsWith?: string | null
+  interestsOriginal_endsWith?: string | null
+  interestsOriginal_not_endsWith?: string | null
   format_isNull?: boolean | null
   format_eq?: string | null
   format_not_eq?: string | null
@@ -1236,6 +1272,117 @@ export interface SpaceWhereInput {
   followers_none?: SpaceFollowersWhereInput | null
   AND?: SpaceWhereInput[] | null
   OR?: SpaceWhereInput[] | null
+}
+
+export interface TweetDetailsWhereInput {
+  createdAt_isNull?: boolean | null
+  createdAt_eq?: string | null
+  createdAt_not_eq?: string | null
+  createdAt_gt?: string | null
+  createdAt_gte?: string | null
+  createdAt_lt?: string | null
+  createdAt_lte?: string | null
+  createdAt_in?: string[] | null
+  createdAt_not_in?: string[] | null
+  createdAt_contains?: string | null
+  createdAt_not_contains?: string | null
+  createdAt_containsInsensitive?: string | null
+  createdAt_not_containsInsensitive?: string | null
+  createdAt_startsWith?: string | null
+  createdAt_not_startsWith?: string | null
+  createdAt_endsWith?: string | null
+  createdAt_not_endsWith?: string | null
+  username_isNull?: boolean | null
+  username_eq?: string | null
+  username_not_eq?: string | null
+  username_gt?: string | null
+  username_gte?: string | null
+  username_lt?: string | null
+  username_lte?: string | null
+  username_in?: string[] | null
+  username_not_in?: string[] | null
+  username_contains?: string | null
+  username_not_contains?: string | null
+  username_containsInsensitive?: string | null
+  username_not_containsInsensitive?: string | null
+  username_startsWith?: string | null
+  username_not_startsWith?: string | null
+  username_endsWith?: string | null
+  username_not_endsWith?: string | null
+  authorId_isNull?: boolean | null
+  authorId_eq?: string | null
+  authorId_not_eq?: string | null
+  authorId_gt?: string | null
+  authorId_gte?: string | null
+  authorId_lt?: string | null
+  authorId_lte?: string | null
+  authorId_in?: string[] | null
+  authorId_not_in?: string[] | null
+  authorId_contains?: string | null
+  authorId_not_contains?: string | null
+  authorId_containsInsensitive?: string | null
+  authorId_not_containsInsensitive?: string | null
+  authorId_startsWith?: string | null
+  authorId_not_startsWith?: string | null
+  authorId_endsWith?: string | null
+  authorId_not_endsWith?: string | null
+  editHistoryTweetIds_isNull?: boolean | null
+  editHistoryTweetIds_containsAll?: (string | null)[] | null
+  editHistoryTweetIds_containsAny?: (string | null)[] | null
+  editHistoryTweetIds_containsNone?: (string | null)[] | null
+  conversationId_isNull?: boolean | null
+  conversationId_eq?: string | null
+  conversationId_not_eq?: string | null
+  conversationId_gt?: string | null
+  conversationId_gte?: string | null
+  conversationId_lt?: string | null
+  conversationId_lte?: string | null
+  conversationId_in?: string[] | null
+  conversationId_not_in?: string[] | null
+  conversationId_contains?: string | null
+  conversationId_not_contains?: string | null
+  conversationId_containsInsensitive?: string | null
+  conversationId_not_containsInsensitive?: string | null
+  conversationId_startsWith?: string | null
+  conversationId_not_startsWith?: string | null
+  conversationId_endsWith?: string | null
+  conversationId_not_endsWith?: string | null
+  inReplyToUserId_isNull?: boolean | null
+  inReplyToUserId_eq?: string | null
+  inReplyToUserId_not_eq?: string | null
+  inReplyToUserId_gt?: string | null
+  inReplyToUserId_gte?: string | null
+  inReplyToUserId_lt?: string | null
+  inReplyToUserId_lte?: string | null
+  inReplyToUserId_in?: string[] | null
+  inReplyToUserId_not_in?: string[] | null
+  inReplyToUserId_contains?: string | null
+  inReplyToUserId_not_contains?: string | null
+  inReplyToUserId_containsInsensitive?: string | null
+  inReplyToUserId_not_containsInsensitive?: string | null
+  inReplyToUserId_startsWith?: string | null
+  inReplyToUserId_not_startsWith?: string | null
+  inReplyToUserId_endsWith?: string | null
+  inReplyToUserId_not_endsWith?: string | null
+  referencedTweets_isNull?: boolean | null
+  attachments_isNull?: boolean | null
+  lang_isNull?: boolean | null
+  lang_eq?: string | null
+  lang_not_eq?: string | null
+  lang_gt?: string | null
+  lang_gte?: string | null
+  lang_lt?: string | null
+  lang_lte?: string | null
+  lang_in?: string[] | null
+  lang_not_in?: string[] | null
+  lang_contains?: string | null
+  lang_not_contains?: string | null
+  lang_containsInsensitive?: string | null
+  lang_not_containsInsensitive?: string | null
+  lang_startsWith?: string | null
+  lang_not_startsWith?: string | null
+  lang_endsWith?: string | null
+  lang_not_endsWith?: string | null
 }
 
 //==============================================================


### PR DESCRIPTION
# Problem
Before, the data is queried using activities data, tracking the create events. But, if using this only, then transferred spaces will still be queried, making space that you don't own still appearing in the profile