### PR TITLE
Mobile UI Improvement for Cards Below Post Page

### DIFF
--- a/src/components/profiles/address-views/AuthorCard.tsx
+++ b/src/components/profiles/address-views/AuthorCard.tsx
@@ -30,7 +30,7 @@ export default function AuthorCard({
   const profile = useSelectProfile(address.toString())
   const accountAvatar = profile?.content?.image
   const isMobile = useIsMobileWidthOrDevice()
-  const isMy = useIsMyAddress(address)
+  const isMyAddress = useIsMyAddress(address)
 
   return (
     <CardWithContent
@@ -54,8 +54,10 @@ export default function AuthorCard({
       }
       subtitle={<DfMd source={profile?.content?.about} className='ColorCurrentColor' />}
       buttons={[
-        withTipButton && !isMy && <Donate key='donate' recipientAddress={address.toString()} />,
-        isMy && profile && (
+        withTipButton && !isMyAddress && (
+          <Donate key='donate' recipientAddress={address.toString()} />
+        ),
+        isMyAddress && profile && (
           <ButtonLink
             key='edit'
             href={'/[spaceId]/edit'}

--- a/src/components/profiles/address-views/AuthorCard.tsx
+++ b/src/components/profiles/address-views/AuthorCard.tsx
@@ -35,7 +35,7 @@ export default function AuthorCard({
   return (
     <CardWithContent
       {...props}
-      avatar={<Avatar address={address} avatar={accountAvatar} size={64} />}
+      avatar={<Avatar noMargin address={address} avatar={accountAvatar} size={64} />}
       title={
         <div className={clsx('d-flex', isMobile ? 'flex-column' : 'align-items-center')}>
           <Name asLink owner={profile} address={address} />
@@ -43,7 +43,7 @@ export default function AuthorCard({
             {withAuthorTag && (
               <Tag
                 color='blue'
-                className={clsx(isMobile ? 'mb-2' : 'ml-2')}
+                className={clsx('mr-0', isMobile ? 'mb-2' : 'ml-2')}
                 icon={<NotificationOutlined />}
               >
                 <span className='font-weight-normal'>Post author</span>

--- a/src/components/profiles/address-views/AuthorCard.tsx
+++ b/src/components/profiles/address-views/AuthorCard.tsx
@@ -53,21 +53,20 @@ export default function AuthorCard({
         </div>
       }
       subtitle={<DfMd source={profile?.content?.about} className='ColorCurrentColor' />}
-      actions={
-        <div className='d-flex align-items-center'>
-          {withTipButton && !isMy && <Donate recipientAddress={address.toString()} />}
-          {isMy && profile && (
-            <ButtonLink
-              href={'/[spaceId]/edit'}
-              as={editSpaceUrl(profile.struct)}
-              className='bg-transparent'
-            >
-              <EditOutlined /> Edit
-            </ButtonLink>
-          )}
-          <FollowAccountButton address={address} />
-        </div>
-      }
+      buttons={[
+        withTipButton && !isMy && <Donate key='donate' recipientAddress={address.toString()} />,
+        isMy && profile && (
+          <ButtonLink
+            key='edit'
+            href={'/[spaceId]/edit'}
+            as={editSpaceUrl(profile.struct)}
+            className='bg-transparent'
+          >
+            <EditOutlined /> Edit
+          </ButtonLink>
+        ),
+        <FollowAccountButton key='follow' address={address} />,
+      ]}
     />
   )
 }

--- a/src/components/spaces/SpaceCard.tsx
+++ b/src/components/spaces/SpaceCard.tsx
@@ -41,22 +41,20 @@ export default function SpaceCard({ spaceId, ...props }: SpaceCardProps) {
         )
       }
       subtitle={<DfMd className='ColorCurrentColor' source={spaceData?.content?.about} />}
-      actions={
-        <div className='d-flex align-items-center'>
-          {spaceData &&
-            (isMySpace ? (
-              <ButtonLink
-                href={'/[spaceId]/edit'}
-                as={editSpaceUrl(spaceData.struct)}
-                className='bg-transparent'
-              >
-                <EditOutlined /> Edit
-              </ButtonLink>
-            ) : (
-              <FollowSpaceButton space={spaceData.struct} />
-            ))}
-        </div>
-      }
+      buttons={[
+        spaceData &&
+          (isMySpace ? (
+            <ButtonLink
+              href={'/[spaceId]/edit'}
+              as={editSpaceUrl(spaceData.struct)}
+              className='bg-transparent'
+            >
+              <EditOutlined /> Edit
+            </ButtonLink>
+          ) : (
+            <FollowSpaceButton space={spaceData.struct} />
+          )),
+      ]}
     />
   )
 }

--- a/src/components/spaces/SpaceCard.tsx
+++ b/src/components/spaces/SpaceCard.tsx
@@ -23,6 +23,7 @@ export default function SpaceCard({ spaceId, ...props }: SpaceCardProps) {
       avatar={
         spaceData && (
           <SpaceAvatar
+            noMargin
             address={spaceData?.struct.ownerId}
             space={spaceData?.struct}
             size={64}

--- a/src/components/utils/DfAvatar.tsx
+++ b/src/components/utils/DfAvatar.tsx
@@ -1,4 +1,5 @@
 import { isEmptyStr } from '@subsocial/utils'
+import clsx from 'clsx'
 import { CSSProperties } from 'react'
 import { DfBgImg, PreviewType } from 'src/components/utils/DfBgImg'
 import IdentityIcon from 'src/components/utils/IdentityIcon'
@@ -11,6 +12,7 @@ export type BaseAvatarProps = {
   avatar?: string
   address?: AnyAccountId
   avatarPreview?: boolean | PreviewType
+  noMargin?: boolean
 }
 
 const avatarCss = 'DfAvatar space ui--IdentityIcon'
@@ -18,7 +20,7 @@ const avatarCss = 'DfAvatar space ui--IdentityIcon'
 // gray overlay comes from antd component
 
 export const BaseAvatar = (props: BaseAvatarProps) => {
-  const { size = DEFAULT_AVATAR_SIZE, avatar, style, address, avatarPreview } = props
+  const { size = DEFAULT_AVATAR_SIZE, avatar, style, address, avatarPreview, noMargin } = props
 
   if (!avatar || isEmptyStr(avatar)) {
     return (
@@ -33,7 +35,7 @@ export const BaseAvatar = (props: BaseAvatarProps) => {
       style={style}
       size={size}
       src={avatar}
-      className={avatarCss}
+      className={clsx(avatarCss, noMargin && 'mr-0')}
       preview={avatarPreview}
       rounded
     />

--- a/src/components/utils/cards/CardWithContent.module.sass
+++ b/src/components/utils/cards/CardWithContent.module.sass
@@ -1,22 +1,31 @@
 @import 'src/styles/subsocial-vars.scss'
 
+.CardWithContent
+  .Avatar
+    margin-right: $space_tiny
+    
+
 @media screen and (max-width: 455px)
   .CardWithContent
     flex-direction: column
     align-items: center
+    
+    .Avatar
+      margin-right: 0
+      margin-top: 0 !important
 
-  .TitleContainer
-    justify-content: center !important
+    .TitleContainer
+      justify-content: center !important
 
-  .Title
-    align-items: center
-    text-align: center
+    .Title
+      align-items: center
+      text-align: center
 
-  .ButtonsContainer
-    display: grid
-    grid-auto-columns: minmax(0, 1fr)
-    grid-auto-flow: column
-    gap: $space_small
+    .ButtonsContainer
+      display: grid
+      grid-auto-columns: minmax(0, 1fr)
+      grid-auto-flow: column
+      gap: $space_small
 
-    button
-      width: 100%
+      button
+        width: 100%

--- a/src/components/utils/cards/CardWithContent.module.sass
+++ b/src/components/utils/cards/CardWithContent.module.sass
@@ -1,8 +1,22 @@
+@import 'src/styles/subsocial-vars.scss'
+
 @media screen and (max-width: 455px)
   .CardWithContent
     flex-direction: column
     align-items: center
 
-    .ActionMobile
-      display: flex
-      justify-content: center
+  .TitleContainer
+    justify-content: center !important
+
+  .Title
+    align-items: center
+    text-align: center
+
+  .ButtonsContainer
+    display: grid
+    grid-auto-columns: minmax(0, 1fr)
+    grid-auto-flow: column
+    gap: $space_small
+
+    button
+      width: 100%

--- a/src/components/utils/cards/CardWithContent.module.sass
+++ b/src/components/utils/cards/CardWithContent.module.sass
@@ -1,0 +1,8 @@
+@media screen and (max-width: 455px)
+  .CardWithContent
+    flex-direction: column
+    align-items: center
+
+    .ActionMobile
+      display: flex
+      justify-content: center

--- a/src/components/utils/cards/CardWithContent.tsx
+++ b/src/components/utils/cards/CardWithContent.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx'
+import { Fragment } from 'react'
 import { useResponsiveSize } from 'src/components/responsive'
 import { MutedSpan } from '../MutedText'
 import styles from './CardWithContent.module.sass'
@@ -10,6 +11,7 @@ export interface CardWithContentProps extends Omit<DfCardProps, 'title'> {
   title: string | JSX.Element
   subtitle?: string | JSX.Element
   actions?: JSX.Element
+  buttons?: (JSX.Element | undefined | null | boolean)[]
 
   moveActionsToBottomInMobile?: boolean
 }
@@ -21,9 +23,12 @@ export default function CardWithContent({
   avatar,
   children,
   moveActionsToBottomInMobile = true,
+  buttons,
   ...props
 }: CardWithContentProps) {
   const { isNotMobile } = useResponsiveSize()
+  const actionsContent =
+    actions || buttons?.map((el, idx) => <Fragment key={idx}>{el || null}</Fragment>)
 
   return (
     <DfCard {...props}>
@@ -36,17 +41,28 @@ export default function CardWithContent({
               'align-items-center',
               'w-100',
               'mb-2',
+              styles.TitleContainer,
             )}
           >
-            <div className={clsx('d-flex align-items-center', 'FontBig font-weight-semibold')}>
+            <div
+              className={clsx(
+                'd-flex align-items-center',
+                'FontBig font-weight-semibold',
+                styles.Title,
+              )}
+            >
               {title}
             </div>
-            {(isNotMobile || !moveActionsToBottomInMobile) && <div>{actions}</div>}
+            {(isNotMobile || !moveActionsToBottomInMobile) && (
+              <div className='d-flex align-items-center'>{actionsContent}</div>
+            )}
           </div>
           {subtitle && <MutedSpan>{subtitle}</MutedSpan>}
           {children}
           {!isNotMobile && moveActionsToBottomInMobile && (
-            <div className={clsx('mt-3', styles.ActionMobile)}>{actions}</div>
+            <div className={clsx('mt-3', actions ? '' : styles.ButtonsContainer)}>
+              {actionsContent}
+            </div>
           )}
         </div>
       </div>

--- a/src/components/utils/cards/CardWithContent.tsx
+++ b/src/components/utils/cards/CardWithContent.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx'
 import { useResponsiveSize } from 'src/components/responsive'
 import { MutedSpan } from '../MutedText'
+import styles from './CardWithContent.module.sass'
 import DfCard, { DfCardProps } from './DfCard'
 
 export interface CardWithContentProps extends Omit<DfCardProps, 'title'> {
@@ -26,8 +27,8 @@ export default function CardWithContent({
 
   return (
     <DfCard {...props}>
-      <div className={clsx('d-flex w-100')}>
-        <div className={clsx(!isNotMobile ? 'mt-2' : '')}>{avatar}</div>
+      <div className={clsx(styles.CardWithContent, 'd-flex w-100')}>
+        <div className={clsx(isNotMobile ? '' : 'mb-2')}>{avatar}</div>
         <div className={clsx('d-flex flex-column w-100', avatar && 'ml-1')}>
           <div
             className={clsx(
@@ -44,7 +45,9 @@ export default function CardWithContent({
           </div>
           {subtitle && <MutedSpan>{subtitle}</MutedSpan>}
           {children}
-          {!isNotMobile && moveActionsToBottomInMobile && <div className={'mt-3'}>{actions}</div>}
+          {!isNotMobile && moveActionsToBottomInMobile && (
+            <div className={clsx('mt-3', styles.ActionMobile)}>{actions}</div>
+          )}
         </div>
       </div>
     </DfCard>

--- a/src/components/utils/cards/CardWithContent.tsx
+++ b/src/components/utils/cards/CardWithContent.tsx
@@ -26,21 +26,21 @@ export default function CardWithContent({
   buttons,
   ...props
 }: CardWithContentProps) {
-  const { isNotMobile } = useResponsiveSize()
+  const { isMobile } = useResponsiveSize()
   const actionsContent =
     actions || buttons?.map((el, idx) => <Fragment key={idx}>{el || null}</Fragment>)
 
   return (
     <DfCard {...props}>
       <div className={clsx(styles.CardWithContent, 'd-flex w-100')}>
-        <div className={clsx('mt-2', isNotMobile ? '' : 'mb-2', styles.Avatar)}>{avatar}</div>
+        <div className={clsx('mt-2', isMobile && 'mb-2', styles.Avatar)}>{avatar}</div>
         <div className={clsx('d-flex flex-column w-100', avatar && 'ml-1')}>
           <div
             className={clsx(
               'd-flex justify-content-between',
               'align-items-center',
               'w-100',
-              'mb-2',
+              'mb-2 GapSmall',
               styles.TitleContainer,
             )}
           >
@@ -53,13 +53,13 @@ export default function CardWithContent({
             >
               {title}
             </div>
-            {(isNotMobile || !moveActionsToBottomInMobile) && (
+            {(!isMobile || !moveActionsToBottomInMobile) && (
               <div className='d-flex align-items-center'>{actionsContent}</div>
             )}
           </div>
           {subtitle && <MutedSpan>{subtitle}</MutedSpan>}
           {children}
-          {!isNotMobile && moveActionsToBottomInMobile && (
+          {isMobile && moveActionsToBottomInMobile && (
             <div className={clsx('mt-3', actions ? '' : styles.ButtonsContainer)}>
               {actionsContent}
             </div>

--- a/src/components/utils/cards/CardWithContent.tsx
+++ b/src/components/utils/cards/CardWithContent.tsx
@@ -33,7 +33,7 @@ export default function CardWithContent({
   return (
     <DfCard {...props}>
       <div className={clsx(styles.CardWithContent, 'd-flex w-100')}>
-        <div className={clsx(isNotMobile ? '' : 'mb-2')}>{avatar}</div>
+        <div className={clsx('mt-2', isNotMobile ? '' : 'mb-2', styles.Avatar)}>{avatar}</div>
         <div className={clsx('d-flex flex-column w-100', avatar && 'ml-1')}>
           <div
             className={clsx(


### PR DESCRIPTION
# Problem
In mobile, the current one have avatar and content side by side which makes things so cramped.
![image](https://user-images.githubusercontent.com/53143942/216621509-7fb1167e-e60e-4f76-a82b-f573d02cfa27.png)

It also makes long texts overflows the card.
![image](https://user-images.githubusercontent.com/53143942/216621821-4638325e-1d80-4321-8aed-88e9226b1f4f.png)

# Fix
The fix is to move the avatar to top
![image](https://user-images.githubusercontent.com/53143942/216666755-63a1bfb2-b82b-408f-9a93-5cb82073ff31.png)
![image](https://user-images.githubusercontent.com/53143942/216666932-4a391fc2-4c6d-4cf1-b093-bce4264f6d48.png)


# Resolves clickup task
https://app.clickup.com/t/85zrkpuyy
