### PR TITLE
Improvement first load for Home Page

### DIFF
--- a/src/components/lists/InfiniteList.tsx
+++ b/src/components/lists/InfiniteList.tsx
@@ -89,7 +89,9 @@ const InnerInfiniteList = <T extends any>(props: InnerInfiniteListProps<T>) => {
 
   const [page, setPage] = useState(initialPage)
   const [data, setData] = useState(dataSource || [])
-  const [loading, setLoading] = useState(false)
+
+  const loadingInitialState = !hasInitialData
+  const [loading, setLoading] = useState(loadingInitialState)
 
   const [hasMore, setHasMore] = useState(canHaveMoreData(dataSource, page))
 

--- a/src/components/main/HomePageFilters.tsx
+++ b/src/components/main/HomePageFilters.tsx
@@ -105,7 +105,16 @@ export const Filters = (props: Props) => {
   return (
     <div className={`DfFilters ${!isAffix ? 'mt-3' : ''}`}>
       <Row className={style.DfGridParams}>
-        {isMobile ? (
+        {!isMobile ? (
+          <Col className={needDateFilter ? style.DfCol : 'ant-col-24'}>
+            <Radio.Group
+              options={filterByKey[tabKey]}
+              onChange={onChangeWrap(onFilterChange)}
+              value={type}
+              optionType={'button'}
+            />
+          </Col>
+        ) : (
           <Col className={needDateFilter ? style.DfCol : 'ant-col-24'}>
             <Select
               value={type}
@@ -118,15 +127,6 @@ export const Filters = (props: Props) => {
                 </Select.Option>
               ))}
             </Select>
-          </Col>
-        ) : (
-          <Col className={needDateFilter ? style.DfCol : 'ant-col-24'}>
-            <Radio.Group
-              options={filterByKey[tabKey]}
-              onChange={onChangeWrap(onFilterChange)}
-              value={type}
-              optionType={'button'}
-            />
           </Col>
         )}
         {needDateFilter && (


### PR DESCRIPTION
# Changes
- Add initial state for loading, so if no initial data, it defaults the loading to true. 
This will make first render for infinite lists without initial data is the loading state, not `not found` state.
This is also okay because we have useEffect that sets the loading to true that runs at first render (deps []). Where it won't run only when `hasInitialData` is true.
In other words, if the `hasInitialData` is false, it will eventually be true after first run of useEffect. So this will just change the first render (ssr) value for the loading state.
- Use `isNotMobile` instead of `isMobile` in home page filters, so in ssr, where the values are all false, it will first render with the combobox (mobile view) instead of radio button (desktop view)