### PR TITLE
Use smaller margin for post preview image in mobile

### DIFF
--- a/src/styles/subsocial-mobile.scss
+++ b/src/styles/subsocial-mobile.scss
@@ -235,7 +235,7 @@
   }
 
   .header.DfPostTitle--preview {
-    margin: $space_tiny 0;
+    margin-bottom: $space_tiny;
   }
 
   .DfPostPreview {
@@ -245,6 +245,9 @@
     }
     &.DfSegment {
       padding-bottom: 0 !important;
+    }
+    .DfPostImagePreviewWrapper {
+      margin-bottom: $space_tiny !important;
     }
     .DfPostImagePreview {
       margin-left: 0 !important;


### PR DESCRIPTION
After:
![image](https://user-images.githubusercontent.com/53143942/217511547-56c443de-0f31-49a6-8338-4cf6ae293cee.png)

Before:
![image](https://user-images.githubusercontent.com/53143942/217511658-1bcd945b-f63a-424d-8d85-449e4faa61dd.png)
