### PR TITLE
Fix error where posts won't show

### DIFF
--- a/src/rtk/app/wrappers.ts
+++ b/src/rtk/app/wrappers.ts
@@ -135,9 +135,7 @@ export function createFetchManyDataWrapper<
       try {
         const res = await getData({ ...newArgs, newIds: needToFetchIds }, thunkApi)
         if (Array.isArray(res)) {
-          res.forEach(content => {
-            data.push(content)
-          })
+          data.push(...res)
         }
       } catch (e) {
         console.error(e)

--- a/src/rtk/app/wrappers.ts
+++ b/src/rtk/app/wrappers.ts
@@ -1,4 +1,5 @@
 import { AsyncThunkPayloadCreator, Dictionary, EntityId } from '@reduxjs/toolkit'
+import { isDef } from '@subsocial/utils'
 import { DataSourceTypes } from 'src/types'
 import {
   CommonFetchPropsWithPrefetch,
@@ -113,20 +114,18 @@ export function createFetchManyDataWrapper<
     const newArgs = { ...args, newIds, dataSource, runAdditionalCheckForUnknownIds }
     let data: ReturnType[] = []
     let needToFetchIds: string[] = []
-    const fetchIdxToOriginalIdxMap: { [key: number]: number } = {}
 
     if (dataSource === DataSourceTypes.SQUID && prefetchedData) {
-      newIds.forEach((id, idx) => {
+      newIds.forEach(id => {
         let content = prefetchedData?.[id]
         if (!content) {
-          fetchIdxToOriginalIdxMap[needToFetchIds.length] = idx
           needToFetchIds.push(id)
           return
         }
         if (withAdditionalUnknownIdValidation) {
           content = { ...content, [withAdditionalUnknownIdValidation.unknownFlagAttr]: true }
         }
-        data[idx] = content
+        data.push(content)
       })
     } else {
       needToFetchIds = newIds
@@ -136,21 +135,21 @@ export function createFetchManyDataWrapper<
       try {
         const res = await getData({ ...newArgs, newIds: needToFetchIds }, thunkApi)
         if (Array.isArray(res)) {
-          res.forEach((content, idx) => {
-            const originalIdx = fetchIdxToOriginalIdxMap[idx] || idx
-            data[originalIdx] = content
+          res.forEach(content => {
+            data.push(content)
           })
         }
       } catch (e) {
         console.error(e)
       }
     }
+    const definedData = data.filter(isDef)
 
     if (handleAfterDataFetch) {
-      const afterDataRes = await handleAfterDataFetch(data, newArgs, thunkApi)
+      const afterDataRes = await handleAfterDataFetch(definedData, newArgs, thunkApi)
       if (afterDataRes) return afterDataRes
     }
-    return data
+    return definedData
   }
 }
 

--- a/src/rtk/features/contents/contentsSlice.ts
+++ b/src/rtk/features/contents/contentsSlice.ts
@@ -1,4 +1,5 @@
 import { AsyncThunk, createAsyncThunk, createEntityAdapter, createSlice } from '@reduxjs/toolkit'
+import { isDef } from '@subsocial/utils'
 import { createFetchOne, SelectByIdFn, ThunkApiConfig } from 'src/rtk/app/helpers'
 import { RootState } from 'src/rtk/app/rootReducer'
 import { createFetchManyDataWrapper } from 'src/rtk/app/wrappers'
@@ -65,10 +66,14 @@ export const fetchContents = createAsyncThunk<
     getData: async ({ api, newIds }) => {
       const timeoutMs = 10_000
       let contents = await api.ipfs.getContentArray(newIds as string[], timeoutMs)
-      return Object.entries(contents).map(([id, content]) => {
-        const derivedContent = convertToDerivedContent(content) as CommentContent
-        return { id, ...derivedContent, isOverview: false }
-      })
+      return Object.entries(contents)
+        .map(([id, content]) => {
+          const isInvalidContent = typeof content === 'string'
+          if (isInvalidContent) return
+          const derivedContent = convertToDerivedContent(content) as CommentContent
+          return { id, ...derivedContent, isOverview: false }
+        })
+        .filter(isDef)
     },
   }),
 )

--- a/src/rtk/features/contents/contentsSlice.ts
+++ b/src/rtk/features/contents/contentsSlice.ts
@@ -68,8 +68,6 @@ export const fetchContents = createAsyncThunk<
       let contents = await api.ipfs.getContentArray(newIds as string[], timeoutMs)
       return Object.entries(contents)
         .map(([id, content]) => {
-          const isInvalidContent = typeof content === 'string'
-          if (isInvalidContent) return
           const derivedContent = convertToDerivedContent(content) as CommentContent
           return { id, ...derivedContent, isOverview: false }
         })


### PR DESCRIPTION
# Problem
If there is a post/space where the content is not there, and error if you get from ipfs, it will make the fetch batch rejects and not setting the data in state even when only 1 is error.
![image](https://user-images.githubusercontent.com/53143942/217608595-fe9ed04c-a472-4bc4-adf7-4faca19f3b0f.png)

This problem is because now, if you have mismatch where you fetch an id but the content is not there, there will be an error in inserting the data, making that batch all fails.
The exact problem is, in the logic of managing prefetch data, the logic preserves the `ids` order, making if you have for example 1 id that the content can't be fetched, there will be `undefined` in the array, making it can't be inserted to the redux.

# Solution
Remove the logic to preserve the order of the ids fetched, because its not needed as redux doesn't store it based on its order, but by the id.
Also, to failsafe, filter the data before returning so undefined data will be filtered.

# Resolves task
https://app.clickup.com/t/860pvx6xc