### PR TITLE
Improvement Tweet Post UI

### DIFF
--- a/src/components/posts/view-post/PostPage.tsx
+++ b/src/components/posts/view-post/PostPage.tsx
@@ -151,6 +151,7 @@ const InnerPostPage: NextPage<PostDetailsProps> = props => {
             <OriginalPostPanel canonicalUrl={content.canonical} />
             {content.tweet ? (
               <TwitterPost
+                withLargeFont
                 className='DfBoxShadowLight mt-4 mb-3'
                 post={post}
                 space={space.struct}

--- a/src/components/posts/view-post/TwitterPost.module.sass
+++ b/src/components/posts/view-post/TwitterPost.module.sass
@@ -17,13 +17,15 @@
       color: inherit
 
   .TwitterPostContent
-    padding: $space_normal $space_large
-    padding-top: $space_small
+    display: flex
+    flex-direction: column
 
     \:global .markdown-body
       font-size: inherit
 
     .TwitterPostBodyContainer
+      padding: $space_normal $space_large
+      padding-top: $space_small
       position: relative
 
       .TwitterPostBodyLink

--- a/src/components/posts/view-post/TwitterPost.module.sass
+++ b/src/components/posts/view-post/TwitterPost.module.sass
@@ -19,7 +19,6 @@
   .TwitterPostContent
     padding: $space_normal $space_large
     padding-top: $space_small
-    font-size: $font_large
 
     \:global .markdown-body
       font-size: inherit

--- a/src/components/posts/view-post/TwitterPost.tsx
+++ b/src/components/posts/view-post/TwitterPost.tsx
@@ -49,7 +49,7 @@ export default function TwitterPost({
         </Link>
       </div>
       <div className={clsx(styles.TwitterPostContent, withLargeFont ? 'FontLarge' : 'FontNormal')}>
-        <PostImage className='CursorPointer my-2' content={content} />
+        <PostImage className='mb-0 BorderNone RoundedNone' content={content} />
         <div className={styles.TwitterPostBodyContainer}>
           {withLinkToDetailPage && (
             <ViewPostLink

--- a/src/components/posts/view-post/TwitterPost.tsx
+++ b/src/components/posts/view-post/TwitterPost.tsx
@@ -13,12 +13,14 @@ export type TwitterPostProps = Omit<HTMLProps<HTMLDivElement>, 'content'> & {
   post: PostData
   space: SpaceStruct | undefined
   withLinkToDetailPage?: boolean
+  withLargeFont?: boolean
 }
 
 export default function TwitterPost({
   post,
   space,
   withLinkToDetailPage,
+  withLargeFont,
   ...props
 }: TwitterPostProps) {
   const { content } = post
@@ -46,7 +48,7 @@ export default function TwitterPost({
           </a>
         </Link>
       </div>
-      <div className={styles.TwitterPostContent}>
+      <div className={clsx(styles.TwitterPostContent, withLargeFont ? 'FontLarge' : 'FontNormal')}>
         <PostImage className='CursorPointer my-2' content={content} />
         <div className={styles.TwitterPostBodyContainer}>
           {withLinkToDetailPage && (

--- a/src/components/posts/view-post/ViewRegularPreview.tsx
+++ b/src/components/posts/view-post/ViewRegularPreview.tsx
@@ -16,8 +16,6 @@ export const RegularPreview: ComponentType = props => {
   const [commentsSection, setCommentsSection] = useState(false)
   const { isSharedPost } = postDetails.post.struct
 
-  const isTwitterContent = !!postDetails.post.content?.tweet?.id
-
   return !isSharedPost ? (
     <>
       <InfoPostPreview
@@ -33,7 +31,6 @@ export const RegularPreview: ComponentType = props => {
           space={space?.struct}
           toogleCommentSection={() => setCommentsSection(!commentsSection)}
           preview
-          withBorder={!isTwitterContent}
         />
       )}
       {commentsSection && (

--- a/src/components/posts/view-post/ViewRegularPreview.tsx
+++ b/src/components/posts/view-post/ViewRegularPreview.tsx
@@ -25,6 +25,7 @@ export const RegularPreview: ComponentType = props => {
         space={space}
         withImage={withImage}
         withTags={withTags}
+        withMarginForCardType={!withActions}
       />
       {withActions && (
         <PostActionsPanel

--- a/src/components/posts/view-post/helpers.tsx
+++ b/src/components/posts/view-post/helpers.tsx
@@ -231,6 +231,7 @@ type PostContentProps = {
   postDetails: PostWithSomeDetails
   space?: SpaceStruct
   withImage?: boolean
+  withMarginForCardType?: boolean
 }
 
 type PostContentMemoizedProps = PostContentProps & {
@@ -238,7 +239,7 @@ type PostContentMemoizedProps = PostContentProps & {
 }
 
 const PostContentMemoized = React.memo((props: PostContentMemoizedProps) => {
-  const { postDetails, space, withImage } = props
+  const { postDetails, space, withImage, withMarginForCardType } = props
 
   if (!postDetails) return null
 
@@ -247,7 +248,11 @@ const PostContentMemoized = React.memo((props: PostContentMemoizedProps) => {
 
   if (!content || isEmptyObj(content)) return null
   if (content.tweet?.id) {
-    return <TwitterPost withLinkToDetailPage space={space} post={post} className='mt-3' />
+    return (
+      <div className={clsx(withMarginForCardType && 'mb-3 pb-1')}>
+        <TwitterPost withLinkToDetailPage space={space} post={post} className={clsx('mt-3')} />
+      </div>
+    )
   }
 
   return (
@@ -341,6 +346,7 @@ type PostPreviewProps = {
   space?: SpaceData
   withImage?: boolean
   withTags?: boolean
+  withMarginForCardType?: boolean
 }
 
 const SharedPostMd = (props: PostPreviewProps) => {
@@ -388,7 +394,7 @@ export const SharePostContent = (props: PostPreviewProps) => {
 }
 
 export const InfoPostPreview: FC<PostPreviewProps> = props => {
-  const { postDetails, space, withImage = true, withTags } = props
+  const { postDetails, space, withImage = true, withTags, withMarginForCardType } = props
   const {
     post: { struct, content },
   } = postDetails
@@ -409,7 +415,12 @@ export const InfoPostPreview: FC<PostPreviewProps> = props => {
             />
           </div>
           {content.link && <Embed link={content.link} className='mt-3' />}
-          <PostContent postDetails={postDetails} space={space?.struct} withImage={withImage} />
+          <PostContent
+            withMarginForCardType={withMarginForCardType && !withTags}
+            postDetails={postDetails}
+            space={space?.struct}
+            withImage={withImage}
+          />
           {withTags && <ViewTags tags={content?.tags} />}
           {/* {withStats && <StatsPanel id={post.id}/>} */}
         </div>

--- a/src/styles/subsocial.scss
+++ b/src/styles/subsocial.scss
@@ -178,6 +178,10 @@ a {
   color: currentColor;
 }
 
+.RoundedNone {
+  border-radius: 0 !important;
+}
+
 .RoundedNormal {
   border-radius: $border_radius_normal;
 }
@@ -198,6 +202,10 @@ a {
 .IconFontSize {
   font-size: 1.25rem;
   cursor: pointer;
+}
+
+.BorderNone {
+  border: none !important;
 }
 
 .DfSegment {


### PR DESCRIPTION
# Improvements
- Fix border bottom of tweet post UI in shared post (currently there is no border bottom)
- Change font size for tweet preview to 16px (same as usual post) in preview and 20px in post detail
- Remove border top from post actions in every post
- Make twitter post image full width
