### PR TITLE
Use same validation for rendering tweet post in post page and preview

### DIFF
--- a/src/components/posts/view-post/PostPage.tsx
+++ b/src/components/posts/view-post/PostPage.tsx
@@ -149,7 +149,7 @@ const InnerPostPage: NextPage<PostDetailsProps> = props => {
               )}
             </div>
             <OriginalPostPanel canonicalUrl={content.canonical} />
-            {content.tweet ? (
+            {content.tweet?.id ? (
               <TwitterPost
                 withLargeFont
                 className='DfBoxShadowLight mt-4 mb-3'


### PR DESCRIPTION
# Problem
Before, to render twitter post UI in post preview, it checks if `content.tweet?.id` is defined, and in post page, it checks if `content.tweet` is defined.

With this PR, it changes the post page one, so it checks `content.tweet?.id` too, so there won't be a case where the preview and detail show different UI. (e.g. if the content.tweet is string)

# Resolves task
https://app.clickup.com/t/85zrmup5b