### PR TITLE
UI Improvement of Space and Author card in post detail page

### DIFF
--- a/src/components/profiles/address-views/AuthorCard.tsx
+++ b/src/components/profiles/address-views/AuthorCard.tsx
@@ -38,7 +38,12 @@ export default function AuthorCard({
       avatar={<Avatar noMargin address={address} avatar={accountAvatar} size={64} />}
       title={
         <div className={clsx('d-flex', isMobile ? 'flex-column' : 'align-items-center')}>
-          <Name asLink owner={profile} address={address} />
+          <Name
+            asLink
+            owner={profile}
+            address={address}
+            className='UnboundedFont font-weight-normal'
+          />
           <div className='FontNormal'>
             {withAuthorTag && (
               <Tag

--- a/src/components/profiles/address-views/AuthorCard.tsx
+++ b/src/components/profiles/address-views/AuthorCard.tsx
@@ -39,7 +39,9 @@ export default function AuthorCard({
       title={
         <div
           className={clsx(
-            isSmallMobile ? 'd-flex align-items-center flex-column' : 'VertAlignMiddleChildren',
+            isSmallMobile
+              ? 'd-flex align-items-center flex-column mx-auto'
+              : 'VertAlignMiddleChildren',
           )}
         >
           <Name

--- a/src/components/profiles/address-views/AuthorCard.tsx
+++ b/src/components/profiles/address-views/AuthorCard.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx'
 import { useIsMyAddress } from 'src/components/auth/MyAccountsContext'
 import { Donate } from 'src/components/donate'
 import Name from 'src/components/profiles/address-views/Name'
-import { useIsMobileWidthOrDevice } from 'src/components/responsive'
+import { useResponsiveSize } from 'src/components/responsive'
 import { editSpaceUrl } from 'src/components/urls'
 import CardWithContent, { CardWithContentProps } from 'src/components/utils/cards/CardWithContent'
 import { ButtonLink } from 'src/components/utils/CustomLinks'
@@ -29,7 +29,7 @@ export default function AuthorCard({
 }: AuthorCardProps) {
   const profile = useSelectProfile(address.toString())
   const accountAvatar = profile?.content?.image
-  const isMobile = useIsMobileWidthOrDevice()
+  const { isSmallMobile } = useResponsiveSize()
   const isMyAddress = useIsMyAddress(address)
 
   return (
@@ -37,24 +37,28 @@ export default function AuthorCard({
       {...props}
       avatar={<Avatar noMargin address={address} avatar={accountAvatar} size={64} />}
       title={
-        <div className={clsx('d-flex', isMobile ? 'flex-column' : 'align-items-center')}>
+        <div
+          className={clsx(
+            isSmallMobile ? 'd-flex align-items-center flex-column' : 'VertAlignMiddleChildren',
+          )}
+        >
           <Name
             asLink
             owner={profile}
             address={address}
             className='UnboundedFont font-weight-normal'
           />
-          <div className='FontNormal'>
+          <span className='FontNormal'>
             {withAuthorTag && (
               <Tag
                 color='blue'
-                className={clsx('mr-0', isMobile ? 'mb-2' : 'ml-2')}
+                className={clsx('mr-0', isSmallMobile ? 'mb-2' : 'ml-2')}
                 icon={<NotificationOutlined />}
               >
                 <span className='font-weight-normal'>Post author</span>
               </Tag>
             )}
-          </div>
+          </span>
         </div>
       }
       subtitle={<DfMd source={profile?.content?.about} className='ColorCurrentColor' />}

--- a/src/components/responsive/ResponsiveContext.tsx
+++ b/src/components/responsive/ResponsiveContext.tsx
@@ -3,6 +3,7 @@ import { useMediaQuery } from 'react-responsive'
 import { isMobileDevice } from 'src/config/Size.config'
 
 export type ResponsiveSizeState = {
+  isSmallMobile: boolean
   isMobile: boolean
   isTablet: boolean
   isDesktop: boolean
@@ -14,6 +15,7 @@ const contextStub: ResponsiveSizeState = {
   isDesktop: true,
   isMobile: false,
   isNotMobile: false,
+  isSmallMobile: true,
   isTablet: false,
   isNotDesktop: false,
 }
@@ -25,6 +27,7 @@ export function ResponsiveSizeProvider(props: React.PropsWithChildren<any>) {
     isDesktop: useMediaQuery({ minWidth: 992 }),
     isTablet: useMediaQuery({ minWidth: 768, maxWidth: 991 }),
     isMobile: useMediaQuery({ maxWidth: 767 }),
+    isSmallMobile: useMediaQuery({ maxWidth: 455 }),
     isNotMobile: useMediaQuery({ minWidth: 768 }),
     isNotDesktop: useMediaQuery({ maxWidth: 991 }),
   }

--- a/src/components/spaces/SpaceCard.tsx
+++ b/src/components/spaces/SpaceCard.tsx
@@ -38,11 +38,12 @@ export default function SpaceCard({ spaceId, ...props }: SpaceCardProps) {
       title={
         spaceData ? (
           <ViewSpaceLink
-            className='UnboundedFont font-weight-normal VertAlignMiddleChildren'
+            containerClassName='w-100'
+            className='font-weight-normal VertAlignMiddleChildren'
             title={
               <>
-                <span>{spaceData.content?.name ?? 'Unnamed Space'}</span>
-                <OfficialSpaceStatus space={spaceData.struct} />
+                <span className='UnboundedFont'>{spaceData.content?.name ?? 'Unnamed Space'}</span>
+                <OfficialSpaceStatus removeContainer space={spaceData.struct} />
                 <MyEntityLabel isMy={isMySpace} className='ml-2'>
                   {spaceId === myProfile?.id ? 'My profile' : 'My space'}
                 </MyEntityLabel>

--- a/src/components/spaces/SpaceCard.tsx
+++ b/src/components/spaces/SpaceCard.tsx
@@ -43,7 +43,7 @@ export default function SpaceCard({ spaceId, ...props }: SpaceCardProps) {
             title={
               <>
                 <span className='UnboundedFont'>{spaceData.content?.name ?? 'Unnamed Space'}</span>
-                <OfficialSpaceStatus removeContainer space={spaceData.struct} />
+                <OfficialSpaceStatus withoutContainer space={spaceData.struct} />
                 <MyEntityLabel isMy={isMySpace} className='ml-2'>
                   {spaceId === myProfile?.id ? 'My profile' : 'My space'}
                 </MyEntityLabel>

--- a/src/components/spaces/SpaceCard.tsx
+++ b/src/components/spaces/SpaceCard.tsx
@@ -34,6 +34,7 @@ export default function SpaceCard({ spaceId, ...props }: SpaceCardProps) {
       title={
         spaceData ? (
           <ViewSpaceLink
+            className='UnboundedFont font-weight-normal'
             title={spaceData.content?.name ?? 'Unnamed Space'}
             space={spaceData.struct}
           />

--- a/src/components/spaces/SpaceCard.tsx
+++ b/src/components/spaces/SpaceCard.tsx
@@ -1,11 +1,13 @@
 import { EditOutlined } from '@ant-design/icons'
 import CardWithContent, { CardWithContentProps } from 'src/components/utils/cards/CardWithContent'
-import { useSelectSpace } from 'src/rtk/app/hooks'
+import { useSelectProfile, useSelectSpace } from 'src/rtk/app/hooks'
+import { useMyAddress } from '../auth/MyAccountsContext'
 import { editSpaceUrl } from '../urls'
 import { ButtonLink } from '../utils/CustomLinks'
 import { DfMd } from '../utils/DfMd'
 import FollowSpaceButton from '../utils/FollowSpaceButton'
-import { SpaceAvatar, useIsMySpace } from './helpers'
+import MyEntityLabel from '../utils/MyEntityLabel'
+import { OfficialSpaceStatus, SpaceAvatar, useIsMySpace } from './helpers'
 import ViewSpaceLink from './ViewSpaceLink'
 
 export interface SpaceCardProps
@@ -15,6 +17,8 @@ export interface SpaceCardProps
 
 export default function SpaceCard({ spaceId, ...props }: SpaceCardProps) {
   const spaceData = useSelectSpace(spaceId)
+  const myAddress = useMyAddress()
+  const myProfile = useSelectProfile(myAddress)
   const isMySpace = useIsMySpace(spaceData?.struct)
 
   return (
@@ -34,8 +38,16 @@ export default function SpaceCard({ spaceId, ...props }: SpaceCardProps) {
       title={
         spaceData ? (
           <ViewSpaceLink
-            className='UnboundedFont font-weight-normal'
-            title={spaceData.content?.name ?? 'Unnamed Space'}
+            className='UnboundedFont font-weight-normal VertAlignMiddleChildren'
+            title={
+              <>
+                <span>{spaceData.content?.name ?? 'Unnamed Space'}</span>
+                <OfficialSpaceStatus space={spaceData.struct} />
+                <MyEntityLabel isMy={isMySpace} className='ml-2'>
+                  {spaceId === myProfile?.id ? 'My profile' : 'My space'}
+                </MyEntityLabel>
+              </>
+            }
             space={spaceData.struct}
           />
         ) : (

--- a/src/components/spaces/ViewSpaceLink.tsx
+++ b/src/components/spaces/ViewSpaceLink.tsx
@@ -8,25 +8,29 @@ type Props = {
   title?: React.ReactNode
   hint?: string
   className?: string
+  containerClassName?: string
 }
 
-export const ViewSpaceLink = React.memo(({ space, title, hint, className }: Props) => {
-  if (!space.id || !title) return null
+export const ViewSpaceLink = React.memo(
+  ({ space, title, hint, className, containerClassName }: Props) => {
+    if (!space.id || !title) return null
 
-  return (
-    <span
-      onClick={e => {
-        e.stopPropagation()
-        e.preventDefault()
-      }}
-    >
-      <Link href='/[spaceId]' as={spaceUrl(space)}>
-        <a className={'DfBlackLink ' + className} title={hint}>
-          {title}
-        </a>
-      </Link>
-    </span>
-  )
-})
+    return (
+      <span
+        className={containerClassName}
+        onClick={e => {
+          e.stopPropagation()
+          e.preventDefault()
+        }}
+      >
+        <Link href='/[spaceId]' as={spaceUrl(space)}>
+          <a className={'DfBlackLink ' + className} title={hint}>
+            {title}
+          </a>
+        </Link>
+      </span>
+    )
+  },
+)
 
 export default ViewSpaceLink

--- a/src/components/spaces/helpers/OfficialSpaceStatus.tsx
+++ b/src/components/spaces/helpers/OfficialSpaceStatus.tsx
@@ -11,7 +11,7 @@ import styles from '../spaces.module.sass'
 type OfficialSpaceStatusProps = {
   space: SpaceStruct
   className?: string
-  removeContainer?: boolean
+  withoutContainer?: boolean
 }
 
 type InnerIconProps = {
@@ -46,7 +46,7 @@ const claimSpaceLink = (
 export const OfficialSpaceStatus = ({
   space,
   className,
-  removeContainer,
+  withoutContainer,
 }: OfficialSpaceStatusProps) => {
   const isMobile = useIsMobileWidthOrDevice()
 
@@ -65,7 +65,7 @@ export const OfficialSpaceStatus = ({
     </>
   )
 
-  if (removeContainer) {
+  if (withoutContainer) {
     return content
   }
 

--- a/src/components/spaces/helpers/OfficialSpaceStatus.tsx
+++ b/src/components/spaces/helpers/OfficialSpaceStatus.tsx
@@ -1,5 +1,6 @@
 import { CheckCircleFilled, HourglassOutlined } from '@ant-design/icons'
 import { Tag, Tooltip } from 'antd'
+import clsx from 'clsx'
 import Link from 'next/link'
 import { useIsMobileWidthOrDevice } from 'src/components/responsive'
 import messages from 'src/messages'
@@ -9,6 +10,8 @@ import styles from '../spaces.module.sass'
 
 type OfficialSpaceStatusProps = {
   space: SpaceStruct
+  className?: string
+  removeContainer?: boolean
 }
 
 type InnerIconProps = {
@@ -40,7 +43,11 @@ const claimSpaceLink = (
   </Link>
 )
 
-export const OfficialSpaceStatus = ({ space }: OfficialSpaceStatusProps) => {
+export const OfficialSpaceStatus = ({
+  space,
+  className,
+  removeContainer,
+}: OfficialSpaceStatusProps) => {
   const isMobile = useIsMobileWidthOrDevice()
 
   if (!isOfficialSpace(space.id)) return null
@@ -49,12 +56,18 @@ export const OfficialSpaceStatus = ({ space }: OfficialSpaceStatusProps) => {
 
   const { title, icon } = isClaimed ? officialSpaceProps : unclaimedSpaceProps
 
-  return (
-    <span className='d-flex align-items-center'>
+  const content = (
+    <>
       <Tooltip title={title} className='mr-2'>
         {icon}
       </Tooltip>
       {!isClaimed && !isMobile && claimSpaceLink}
-    </span>
+    </>
   )
+
+  if (removeContainer) {
+    return content
+  }
+
+  return <span className={clsx('d-flex align-items-center', className)}>{content}</span>
 }

--- a/src/components/utils/cards/CardWithContent.tsx
+++ b/src/components/utils/cards/CardWithContent.tsx
@@ -46,7 +46,7 @@ export default function CardWithContent({
           >
             <div
               className={clsx(
-                'd-flex align-items-center',
+                'd-flex align-items-center w-100',
                 'FontBig font-weight-semibold',
                 styles.Title,
               )}

--- a/src/styles/subsocial.scss
+++ b/src/styles/subsocial.scss
@@ -158,6 +158,12 @@ a {
   gap: $space_huge;
 }
 
+.VertAlignMiddleChildren {
+  > * {
+    vertical-align: middle;
+  }
+}
+
 .LineHeightNormal {
   line-height: $line-height-normal;
 }


### PR DESCRIPTION
# Improvement UI for post & author card
## Changes
Most of the changes below are in author and space card in post detail page
- Use better way to display tag beside name (in title). Currently use display flex, so it won't look good for long usernames that wraps to > 1 line.
- Change title font to unbounded
- Add check mark and my profile/my space label beside space card title
- Add `isSmallMobile` for responsive size (`max-width: 455px`). This is because the current mobile breakpoint is still so big, and previously, there are also some styles that have this breakpoint, so I add this to the breakpoint hook

## Images
Before:
![image](https://user-images.githubusercontent.com/53143942/218463219-e62d7c60-d91b-4e07-9e6d-1c72b1a557c5.png)
After:
![image](https://user-images.githubusercontent.com/53143942/218463287-69a2d38c-b2f6-4bba-8003-38f128510c18.png)

# Improvement UI in nested comments
## Changes
- Add align center to fix issue in nested comment mobile

## Images
Before:
![image](https://user-images.githubusercontent.com/53143942/218465191-c0d58e04-64ad-43c3-b77b-94528499c772.png)
After:
![image](https://user-images.githubusercontent.com/53143942/218464888-98cdd72c-057a-4f2f-9ae2-89020d36afa5.png)

# Resolves task
https://app.clickup.com/t/85zrmunx1
https://app.clickup.com/t/85zrmxtzq