### PR TITLE
Add Tweets Tab in Account Activity

### DIFF
--- a/src/components/activity/AccountActivity.tsx
+++ b/src/components/activity/AccountActivity.tsx
@@ -122,10 +122,13 @@ const OffchainAccountActivity = ({ address }: ActivitiesByAddressProps) => {
   const router = useRouter()
   const [activeTab, setActiveTab] = useState<ActivityTab>('posts')
   const [counts, setCounts] = useState<ActivityCounts>()
+  // to make tweets tab doesn't disappear until the address is changed.
+  const [haveDisplayedTweetsTab, setHaveDisplayedTweetsTab] = useState(false)
 
   useEffect(() => {
     setActiveTab('posts')
     setCounts(undefined)
+    setHaveDisplayedTweetsTab(false)
     ;(async () => {
       if (!address) return
 
@@ -133,6 +136,10 @@ const OffchainAccountActivity = ({ address }: ActivitiesByAddressProps) => {
       setCounts(counts)
     })()
   }, [address])
+
+  useEffect(() => {
+    if (activeTab === 'tweets') setHaveDisplayedTweetsTab(true)
+  }, [activeTab])
 
   useEffect(() => {
     const hash = window.location.hash.substring(1) as ActivityTab
@@ -167,7 +174,7 @@ const OffchainAccountActivity = ({ address }: ActivitiesByAddressProps) => {
       <TabPane tab={getTabTitle('Posts', postsCount)} key={getTab('posts')}>
         <PostActivities address={address} totalCount={postsCount} />
       </TabPane>
-      {tweetsCount > 0 && (
+      {(tweetsCount > 0 || haveDisplayedTweetsTab) && (
         <TabPane tab={getTabTitle('Tweets', tweetsCount)} key={getTab('tweets')}>
           <TweetActivities address={address} totalCount={tweetsCount} />
         </TabPane>

--- a/src/components/activity/AccountActivity.tsx
+++ b/src/components/activity/AccountActivity.tsx
@@ -166,7 +166,7 @@ const OffchainAccountActivity = ({ address }: ActivitiesByAddressProps) => {
 
   const onChangeTab = (activeKey: string) => {
     setActiveTab(activeKey as ActivityTab)
-    router.push('#' + activeKey)
+    router.replace('#' + activeKey)
   }
 
   return (

--- a/src/components/activity/AccountActivity.tsx
+++ b/src/components/activity/AccountActivity.tsx
@@ -1,6 +1,8 @@
 import { Tabs } from 'antd'
+import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 import config from 'src/config'
+import { ActivityCounts } from 'src/graphql/apis'
 import {
   useGetActivityCounts,
   useGetAllActivities,
@@ -8,8 +10,8 @@ import {
   useGetFollowActivities,
   useGetPostActivities,
   useGetReactionActivities,
+  useGetTweetActivities,
 } from 'src/graphql/hooks'
-import { Counts } from 'src/types'
 import { Loading } from '../utils'
 import { createLoadMorePosts, FeedActivities } from './FeedActivities'
 import { createLoadMoreActivities, NotifActivities } from './Notifications'
@@ -90,11 +92,40 @@ const PostActivities = (props: BaseActivityProps) => {
     />
   )
 }
+
+const TweetActivities = (props: BaseActivityProps) => {
+  const getTweetActivities = useGetTweetActivities()
+  const loadMorePosts = createLoadMorePosts(getTweetActivities)
+  return (
+    <FeedActivities
+      {...props}
+      loadMore={loadMorePosts}
+      noDataDesc='No tweets yet'
+      loadingLabel='Loading tweets...'
+    />
+  )
+}
+
+const activityTabs = [
+  'posts',
+  'tweets',
+  'comments',
+  'reactions',
+  'follows',
+  'spaces',
+  'all',
+] as const
+type ActivityTab = typeof activityTabs[number]
+const getTab = (tab: ActivityTab) => tab
 const OffchainAccountActivity = ({ address }: ActivitiesByAddressProps) => {
   const getActivityCounts = useGetActivityCounts()
-  const [counts, setCounts] = useState<Counts>()
+  const router = useRouter()
+  const [activeTab, setActiveTab] = useState<ActivityTab>('posts')
+  const [counts, setCounts] = useState<ActivityCounts>()
 
   useEffect(() => {
+    setActiveTab('posts')
+    setCounts(undefined)
     ;(async () => {
       if (!address) return
 
@@ -103,41 +134,69 @@ const OffchainAccountActivity = ({ address }: ActivitiesByAddressProps) => {
     })()
   }, [address])
 
+  useEffect(() => {
+    const hash = window.location.hash.substring(1) as ActivityTab
+    if (activityTabs.includes(hash)) {
+      setActiveTab(hash)
+    }
+  }, [])
+
   if (!counts) return <Loading label='Loading activities...' />
 
-  const { postsCount, commentsCount, reactionsCount, followsCount, activitiesCount, spacesCount } =
-    counts
+  const {
+    postsCount,
+    commentsCount,
+    reactionsCount,
+    followsCount,
+    activitiesCount,
+    spacesCount,
+    tweetsCount,
+  } = counts
 
   const getTabTitle = (title: string, count: number) => `${title} (${count})`
 
   const panePaddingClass = 'px-1 px-md-0'
 
+  const onChangeTab = (activeKey: string) => {
+    setActiveTab(activeKey as ActivityTab)
+    router.push('#' + activeKey)
+  }
+
   return (
-    <Tabs>
-      <TabPane tab={getTabTitle('Posts', postsCount)} key='posts'>
+    <Tabs activeKey={activeTab} onChange={onChangeTab}>
+      <TabPane tab={getTabTitle('Posts', postsCount)} key={getTab('posts')}>
         <PostActivities address={address} totalCount={postsCount} />
       </TabPane>
-      <TabPane tab={getTabTitle('Comments', commentsCount)} key='comments'>
+      {tweetsCount > 0 && (
+        <TabPane tab={getTabTitle('Tweets', tweetsCount)} key={getTab('tweets')}>
+          <TweetActivities address={address} totalCount={tweetsCount} />
+        </TabPane>
+      )}
+      <TabPane tab={getTabTitle('Comments', commentsCount)} key={getTab('comments')}>
         <CommentActivities address={address} totalCount={commentsCount} />
       </TabPane>
       <TabPane
         tab={getTabTitle('Reactions', reactionsCount)}
-        key='reactions'
+        key={getTab('reactions')}
         className={panePaddingClass}
       >
         <ReactionActivities address={address} totalCount={reactionsCount} />
       </TabPane>
       <TabPane
         tab={getTabTitle('Follows', followsCount)}
-        key='follows'
+        key={getTab('follows')}
         className={panePaddingClass}
       >
         <FollowActivities address={address} totalCount={followsCount} />
       </TabPane>
-      <TabPane tab={getTabTitle('Spaces', spacesCount)} key='spaces'>
+      <TabPane tab={getTabTitle('Spaces', spacesCount)} key={getTab('spaces')}>
         <SpaceActivities address={address} totalCount={spacesCount} />
       </TabPane>
-      <TabPane tab={getTabTitle('All', activitiesCount)} key='all' className={panePaddingClass}>
+      <TabPane
+        tab={getTabTitle('All', activitiesCount)}
+        key={getTab('all')}
+        className={panePaddingClass}
+      >
         <AllActivities address={address} totalCount={activitiesCount} />
       </TabPane>
     </Tabs>

--- a/src/graphql/__generated__/GetActivityCounts.ts
+++ b/src/graphql/__generated__/GetActivityCounts.ts
@@ -17,6 +17,11 @@ export interface GetActivityCounts_posts {
   totalCount: number;
 }
 
+export interface GetActivityCounts_tweets {
+  __typename: "PostsConnection";
+  totalCount: number;
+}
+
 export interface GetActivityCounts_spaces {
   __typename: "SpacesConnection";
   totalCount: number;
@@ -40,6 +45,7 @@ export interface GetActivityCounts_follows {
 export interface GetActivityCounts {
   activities: GetActivityCounts_activities;
   posts: GetActivityCounts_posts;
+  tweets: GetActivityCounts_tweets;
   spaces: GetActivityCounts_spaces;
   comments: GetActivityCounts_comments;
   reactions: GetActivityCounts_reactions;

--- a/src/graphql/__generated__/GetTweetActivities.ts
+++ b/src/graphql/__generated__/GetTweetActivities.ts
@@ -1,0 +1,28 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: GetTweetActivities
+// ====================================================
+
+export interface GetTweetActivities_accountById_posts {
+  __typename: "Post";
+  id: string;
+}
+
+export interface GetTweetActivities_accountById {
+  __typename: "Account";
+  posts: GetTweetActivities_accountById_posts[];
+}
+
+export interface GetTweetActivities {
+  accountById: GetTweetActivities_accountById | null;
+}
+
+export interface GetTweetActivitiesVariables {
+  address: string;
+  offset?: number | null;
+  limit: number;
+}

--- a/src/graphql/apis/index.ts
+++ b/src/graphql/apis/index.ts
@@ -91,21 +91,23 @@ export async function getPostIdsBySpaces(
   return res.data.posts.map(({ id }) => id)
 }
 
+export type ActivityCounts = Counts & { tweetsCount: number }
 export async function getActivityCounts(
   client: GqlClient,
   variables: GetActivityCountsVariables,
-): Promise<Counts> {
+): Promise<ActivityCounts> {
   const res = await client.query<GetActivityCounts, GetActivityCountsVariables>({
     query: q.GET_ACTIVITY_COUNTS,
     variables,
   })
 
-  const { activities, comments, follows, posts, reactions, spaces } = res.data
+  const { activities, comments, follows, posts, reactions, spaces, tweets } = res.data
   return {
     activitiesCount: activities.totalCount,
     commentsCount: comments.totalCount,
     followsCount: follows.totalCount,
     postsCount: posts.totalCount,
+    tweetsCount: tweets.totalCount,
     reactionsCount: reactions.totalCount,
     spacesCount: spaces.totalCount,
   }
@@ -186,6 +188,21 @@ export async function getSpaceActivities(
 export async function getPostActivities(client: GqlClient, variables: GetPostActivitiesVariables) {
   const activities = await client.query<GetPostActivities, GetPostActivitiesVariables>({
     query: q.GET_POST_ACTIVITIES,
+    variables,
+  })
+  const postIds: string[] = []
+  activities.data.accountById?.posts.forEach(post => {
+    const postId = post?.id
+    if (postId) {
+      postIds.push(postId)
+    }
+  })
+  return postIds
+}
+
+export async function getTweetActivities(client: GqlClient, variables: GetPostActivitiesVariables) {
+  const activities = await client.query<GetPostActivities, GetPostActivitiesVariables>({
+    query: q.GET_TWEET_ACTIVITIES,
     variables,
   })
   const postIds: string[] = []

--- a/src/graphql/hooks.ts
+++ b/src/graphql/hooks.ts
@@ -12,6 +12,7 @@ import {
   getPostActivities,
   getReactionActivities,
   getSpaceActivities,
+  getTweetActivities,
 } from './apis'
 import { GqlClient, useDfApolloClient } from './ApolloProvider'
 
@@ -40,12 +41,14 @@ export const useGetActivityCounts = createGqlHooks(getActivityCounts, {
   postsCount: 0,
   reactionsCount: 0,
   spacesCount: 0,
+  tweetsCount: 0,
 })
 export const useGetAllActivities = createGqlHooks(getAllActivities, [])
 export const useGetFollowActivities = createGqlHooks(getFollowActivities, [])
 export const useGetReactionActivities = createGqlHooks(getReactionActivities, [])
 export const useGetSpaceActivities = createGqlHooks(getSpaceActivities, [])
 export const useGetPostActivities = createGqlHooks(getPostActivities, [])
+export const useGetTweetActivities = createGqlHooks(getTweetActivities, [])
 export const useGetCommentActivities = createGqlHooks(getCommentActivities, [])
 
 export const useGetNotificationsCount = createGqlHooks(getNotificationCount, 0)

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -434,6 +434,17 @@ export const GET_ACTIVITY_COUNTS = gql`
     ) {
       totalCount
     }
+    tweets: postsConnection(
+      orderBy: id_ASC
+      where: {
+        ownedByAccount: { id_eq: $address }
+        tweetId_isNull: false
+        isComment_eq: false
+        hidden_eq: false
+      }
+    ) {
+      totalCount
+    }
     spaces: spacesConnection(orderBy: id_ASC, where: { ownedByAccount: { id_eq: $address } }) {
       totalCount
     }
@@ -559,6 +570,21 @@ export const GET_POST_ACTIVITIES = gql`
         offset: $offset
         orderBy: createdAtTime_DESC
         where: { isComment_eq: false, hidden_eq: false }
+      ) {
+        id
+      }
+    }
+  }
+`
+
+export const GET_TWEET_ACTIVITIES = gql`
+  query GetTweetActivities($address: String!, $offset: Int = 0, $limit: Int!) {
+    accountById(id: $address) {
+      posts(
+        limit: $limit
+        offset: $offset
+        orderBy: createdAtTime_DESC
+        where: { isComment_eq: false, hidden_eq: false, tweetId_isNull: false }
       ) {
         id
       }


### PR DESCRIPTION
# Changes
- Add tweets tab in account activity page. This tab won't show up if user have 0 tweets. Except, if user specifically access `#tweets` in the first load.
- Add hash url to change tab according to the one in hash. This enables sharing a link to specific tab (e.g. `/.../accountid#tweets`). Note that this uses replace, so if change tabs 5 times and go back, it still will go back to previous link, instead of previous tab (hash)

# Related task
https://app.clickup.com/t/861mbvnxp
