### PR TITLE
Make some sidebar links open in new tab

### DIFF
--- a/src/layout/SideMenu.tsx
+++ b/src/layout/SideMenu.tsx
@@ -35,7 +35,7 @@ const renderPageLink = (item: PageLink) => {
       key={item.page[1] || item.page[0]}
       onClick={() => !openInNewTab && goToPage(item.page)}
     >
-      <Link href={item.page[0]} as={item.page[1]}>
+      <Link href={item.page[0]} as={item.page[1]} passHref>
         <a {...anchorProps}>
           {icon}
           <span className='MenuItemName'>{item.name}</span>

--- a/src/layout/SideMenu.tsx
+++ b/src/layout/SideMenu.tsx
@@ -3,6 +3,7 @@ import { Menu } from 'antd'
 import clsx from 'clsx'
 import Link from 'next/link'
 import Router, { useRouter } from 'next/router'
+import { HTMLProps } from 'react'
 import { useIsSignedIn, useMyAddress } from '../components/auth/MyAccountsContext'
 import { buildAuthorizedMenu, DefaultMenu, isDivider, PageLink } from './SideMenuItems'
 import styles from './Sider.module.sass'
@@ -14,20 +15,28 @@ const goToPage = ([url, as]: string[]) => {
 }
 
 const renderPageLink = (item: PageLink) => {
-  const { icon } = item
+  const { icon, openInNewTab } = item
 
   if (item.hidden) {
     return null
+  }
+
+  let anchorProps: HTMLProps<HTMLAnchorElement> = {}
+  if (openInNewTab) {
+    anchorProps = {
+      target: '_blank',
+      rel: 'noopener noreferrer',
+    }
   }
 
   return (
     <Menu.Item
       className='DfMenuItem'
       key={item.page[1] || item.page[0]}
-      onClick={() => goToPage(item.page)}
+      onClick={() => !openInNewTab && goToPage(item.page)}
     >
       <Link href={item.page[0]} as={item.page[1]}>
-        <a>
+        <a {...anchorProps}>
           {icon}
           <span className='MenuItemName'>{item.name}</span>
         </a>

--- a/src/layout/SideMenuItems.tsx
+++ b/src/layout/SideMenuItems.tsx
@@ -69,6 +69,7 @@ export const DefaultMenu: MenuItem[] = [
     name: 'Subsocial Twitter',
     page: ['https://twitter.com/subsocialchain'],
     icon: <SubIcon Icon={FiTwitter} />,
+    openInNewTab: true,
   },
   // {
   //   name: 'Official Telegram chat',
@@ -79,11 +80,13 @@ export const DefaultMenu: MenuItem[] = [
     name: 'Subsocial Announcements',
     page: ['https://t.me/SubsocialNetwork'],
     icon: <NotificationOutlined />,
+    openInNewTab: true,
   },
   {
     name: 'Subsocial Discord',
     page: ['https://discord.gg/yU8tgHN'],
     icon: <SubIcon Icon={FaDiscord} />,
+    openInNewTab: true,
   },
   Divider,
   {

--- a/src/layout/SideMenuItems.tsx
+++ b/src/layout/SideMenuItems.tsx
@@ -19,7 +19,7 @@ import config from 'src/config'
 
 const { enableSubnetMode, enableDomains } = config
 
-const issuesUrl = 'https://github.com/dappforce/subsocial/issues'
+const issuesUrl = 'https://forms.clickup.com/9008022125/f/8ceq0kd-7261/7PAH62P0XTHM9UIV4Q'
 
 export type Divider = 'Divider'
 
@@ -30,6 +30,7 @@ export type PageLink = {
   page: string[]
   icon: React.ReactNode
   hidden?: boolean
+  openInNewTab?: boolean
 
   // Helpers
   isNotifications?: boolean
@@ -97,11 +98,13 @@ export const DefaultMenu: MenuItem[] = [
       'https://forms.clickup.com/9008022125/p/f/8ceq0kd-8261/FLJSBRH2PYGGK5K7Z9/suggestafeature',
     ],
     icon: <BulbOutlined />,
+    openInNewTab: true,
   },
   {
     name: 'Report bug',
     page: [issuesUrl],
     icon: <BugOutlined />,
+    openInNewTab: true,
   },
 ]
 


### PR DESCRIPTION
# Links that opens in new tab
- Report Bug
- Suggest Feature
- Twitter
- Announcement (Telegram)
- Discord

Also, changed report bug link to clickup form

# Note
For the ones that open in new tab, I remove the onclick that create log when the routing errors. This is because open in new tab won't work with the onClick still attached.