### PR TITLE
Fix large space from margin top in SignIn modal title

### DIFF
--- a/src/components/auth/signIn/SignInModal.module.sass
+++ b/src/components/auth/signIn/SignInModal.module.sass
@@ -63,7 +63,7 @@
   h2
     line-height: 28px
     color: $color_font_normal
-    margin: $space_large 0 $space_tiny 0 !important
+    margin: 0 0 $space_tiny 0 !important
 
   div
     font-size: $font_normal


### PR DESCRIPTION
## Resolved task
https://app.clickup.com/t/860q2dpfw