### PR TITLE
Remove apollo caching in server

### DIFF
--- a/src/graphql/client.ts
+++ b/src/graphql/client.ts
@@ -1,5 +1,6 @@
-import { ApolloClient, InMemoryCache, NormalizedCacheObject } from '@apollo/client'
+import { ApolloClient, DefaultOptions, InMemoryCache, NormalizedCacheObject } from '@apollo/client'
 import { useMemo } from 'react'
+import { isServerSide } from 'src/components/utils'
 import config from 'src/config'
 
 const { enableGraphQl, graphqlUrl } = config
@@ -12,8 +13,18 @@ export function getApolloClient() {
 }
 
 const createApolloClient = (graphqlUrl: string): ApolloClient<NormalizedCacheObject> => {
+  let config: DefaultOptions = {}
+  if (isServerSide()) {
+    config = {
+      query: {
+        fetchPolicy: 'no-cache',
+      },
+    }
+  }
+
   return new ApolloClient({
     uri: graphqlUrl,
+    defaultOptions: config,
     cache: new InMemoryCache(),
   })
 }


### PR DESCRIPTION
# Problem
Because the instance of client is only one (with singleton), in server, the cache size of the apollo client will build up over time and takes up too much RAM.

# Solution
Remove the cache for all queries that are done in server, because we also want to use the newest data to build our page.