### PR TITLE
Fix Reaction and Follow Activity

### DIFF
--- a/src/components/activity/Notification.tsx
+++ b/src/components/activity/Notification.tsx
@@ -360,7 +360,6 @@ const CommentReactionNotification = (props: NotificationProps) => {
     : undefined
   const postDetails = useSelectPost(rootPostId)
 
-  console.log(postDetails)
   if (!postDetails) return null
 
   const { post, space } = postDetails

--- a/src/components/activity/Notification.tsx
+++ b/src/components/activity/Notification.tsx
@@ -41,11 +41,13 @@ type PostTitleForActivityProps = {
   post: PostData
 }
 const PostTitleForActivity = React.memo(({ post: { content } }: PostTitleForActivityProps) => {
-  if (!content) return null // ? Maybe use some text? Example: 'link' or 'see here'
+  const noContentText = 'link'
+  if (!content) return <>{noContentText}</>
 
   const { title, summary } = content
 
-  return <>{title || summarize(summary, { limit: NAME_MAX_LEN })}</>
+  const summarizedContent = title || summarize(summary, { limit: NAME_MAX_LEN })
+  return <>{summarizedContent || noContentText}</>
 })
 
 const NotificationMessage = ({
@@ -358,6 +360,7 @@ const CommentReactionNotification = (props: NotificationProps) => {
     : undefined
   const postDetails = useSelectPost(rootPostId)
 
+  console.log(postDetails)
   if (!postDetails) return null
 
   const { post, space } = postDetails

--- a/src/components/activity/Notification.tsx
+++ b/src/components/activity/Notification.tsx
@@ -292,17 +292,11 @@ const reactionWordingMap = {
     Upvote: 'removed upvote',
     Downvote: 'removed downvote',
   },
-  ReactionUpdated: {
-    Upvote: 'upvoted',
-    Downvote: 'downvoted',
-  },
 }
 function getReactionType(event: EventsName, reactionKind: ReactionType | undefined) {
   let reactionType: keyof typeof reactionWordingMap
   if (event.endsWith('ReactionDeleted')) {
     reactionType = 'ReactionDeleted'
-  } else if (event.endsWith('ReactionUpdated')) {
-    reactionType = 'ReactionUpdated'
   } else {
     reactionType = 'ReactionCreated'
   }

--- a/src/components/activity/Notification.tsx
+++ b/src/components/activity/Notification.tsx
@@ -183,13 +183,13 @@ const AccountNotification = (props: NotificationProps) => {
   const { followingId } = props
   const profile = useSelectProfile(followingId)
 
-  if (!profile) return null
+  if (!followingId) return null
 
-  const address = profile.struct.ownerId
+  const address = followingId
   return (
     <InnerNotification
       preview={<Name owner={profile} address={address} />}
-      image={profile.content?.image}
+      image={profile?.content?.image}
       entityOwner={address}
       links={{
         href: '/[spaceId]',
@@ -296,6 +296,7 @@ const CommentNotification = (props: NotificationProps) => {
 export const Notification = React.memo((props: NotificationProps) => {
   const { event } = props
   const eventName = event
+  console.log(event)
 
   switch (eventName) {
     case 'AccountFollowed':

--- a/src/components/activity/Notification.tsx
+++ b/src/components/activity/Notification.tsx
@@ -357,7 +357,6 @@ const CommentReactionNotification = (props: NotificationProps) => {
     ? asCommentData(commentDetails.post)?.struct?.rootPostId
     : undefined
   const postDetails = useSelectPost(rootPostId)
-  console.log(commentId, commentDetails, rootPostId, postDetails)
 
   if (!postDetails) return null
 

--- a/src/graphql/__generated__/GetAllActivity.ts
+++ b/src/graphql/__generated__/GetAllActivity.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { EventName } from "./../../types/graphql-global-types";
+import { EventName, ReactionKind } from "./../../types/graphql-global-types";
 
 // ====================================================
 // GraphQL query operation: GetAllActivity
@@ -51,6 +51,10 @@ export interface GetAllActivity_accountById_activities_reaction {
    * The ID of a Reaction, which will have the same value and reaction ID on the blockchain.
    */
   id: string;
+  /**
+   * The type of Reaction (Upvote, Downvote).
+   */
+  kind: ReactionKind;
 }
 
 export interface GetAllActivity_accountById_activities {

--- a/src/graphql/__generated__/GetNotifications.ts
+++ b/src/graphql/__generated__/GetNotifications.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { EventName } from "./../../types/graphql-global-types";
+import { EventName, ReactionKind } from "./../../types/graphql-global-types";
 
 // ====================================================
 // GraphQL query operation: GetNotifications
@@ -51,6 +51,10 @@ export interface GetNotifications_notifications_activity_reaction {
    * The ID of a Reaction, which will have the same value and reaction ID on the blockchain.
    */
   id: string;
+  /**
+   * The type of Reaction (Upvote, Downvote).
+   */
+  kind: ReactionKind;
 }
 
 export interface GetNotifications_notifications_activity {

--- a/src/graphql/__generated__/GetReactionActivities.ts
+++ b/src/graphql/__generated__/GetReactionActivities.ts
@@ -28,6 +28,10 @@ export interface GetReactionActivities_accountById_activities_reaction {
 export interface GetReactionActivities_accountById_activities_post {
   __typename: "Post";
   /**
+   * Is the current Post a Comment to a Regular Post or a Comment Post?
+   */
+  isComment: boolean;
+  /**
    * The Post ID, the same as it is on the blockchain.
    */
   id: string;

--- a/src/graphql/__generated__/GetReactionActivities.ts
+++ b/src/graphql/__generated__/GetReactionActivities.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { EventName } from "./../../types/graphql-global-types";
+import { EventName, ReactionKind } from "./../../types/graphql-global-types";
 
 // ====================================================
 // GraphQL query operation: GetReactionActivities
@@ -15,6 +15,14 @@ export interface GetReactionActivities_accountById_activities_account {
    * The account's public key converted to ss58 format for the Subsocial chain (prefix "28")
    */
   id: string;
+}
+
+export interface GetReactionActivities_accountById_activities_reaction {
+  __typename: "Reaction";
+  /**
+   * The type of Reaction (Upvote, Downvote).
+   */
+  kind: ReactionKind;
 }
 
 export interface GetReactionActivities_accountById_activities_post {
@@ -55,6 +63,10 @@ export interface GetReactionActivities_accountById_activities {
    * Is this Activity the most recent in the list of Activities of this type (same event) from this account?
    */
   aggregated: boolean | null;
+  /**
+   * A One-to-One relationship with the Reaction that is involved in the current Activity
+   */
+  reaction: GetReactionActivities_accountById_activities_reaction | null;
   /**
    * A One-to-One relationship with the Post that is involved in the current Activity
    */

--- a/src/graphql/__generated__/GetTweetActivities.ts
+++ b/src/graphql/__generated__/GetTweetActivities.ts
@@ -9,11 +9,17 @@
 
 export interface GetTweetActivities_accountById_posts {
   __typename: "Post";
+  /**
+   * The Post ID, the same as it is on the blockchain.
+   */
   id: string;
 }
 
 export interface GetTweetActivities_accountById {
   __typename: "Account";
+  /**
+   * A One-To-Many relationship with the Posts which are created by an Account (foreign key - "createdByAccount")
+   */
   posts: GetTweetActivities_accountById_posts[];
 }
 

--- a/src/graphql/apis/index.ts
+++ b/src/graphql/apis/index.ts
@@ -165,8 +165,10 @@ export async function getReactionActivities(
   })
   return (
     activities.data.accountById?.activities.map<Activity>(activity => {
+      const isComment = activity.post?.isComment
       return mapActivityQueryResult(activity, {
-        postId: activity.post?.id,
+        postId: !isComment ? activity.post?.id : undefined,
+        commentId: isComment ? activity.post?.id : undefined,
         reactionKind: activity.reaction?.kind,
       })
     }) ?? []

--- a/src/graphql/apis/index.ts
+++ b/src/graphql/apis/index.ts
@@ -131,6 +131,7 @@ export async function getAllActivities(client: GqlClient, variables: GetAllActiv
         postId: !isComment ? activity.post?.id : undefined,
         commentId: isComment ? activity.post?.id : undefined,
         event: mapCommentEventNames(activity.event, isComment),
+        reactionKind: activity.reaction?.kind,
       })
     }) ?? []
   )
@@ -166,6 +167,7 @@ export async function getReactionActivities(
     activities.data.accountById?.activities.map<Activity>(activity => {
       return mapActivityQueryResult(activity, {
         postId: activity.post?.id,
+        reactionKind: activity.reaction?.kind,
       })
     }) ?? []
   )
@@ -262,6 +264,7 @@ export async function getAllNotifications(client: GqlClient, variables: GetNotif
         postId: !isComment ? activity.post?.id : undefined,
         commentId: isComment ? activity.post?.id : undefined,
         event: mapCommentEventNames(activity.event, isComment),
+        reactionKind: activity.reaction?.kind,
       })
     }) ?? []
   )

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -595,6 +595,7 @@ export const GET_REACTION_ACTIVITIES = gql`
           kind
         }
         post {
+          isComment
           id
         }
       }

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -539,6 +539,7 @@ export const GET_ALL_ACTIVITY = gql`
         }
         reaction {
           id
+          kind
         }
       }
     }
@@ -590,6 +591,9 @@ export const GET_REACTION_ACTIVITIES = gql`
         orderBy: date_DESC
       ) {
         ...ActivityRequiredFragment
+        reaction {
+          kind
+        }
         post {
           id
         }
@@ -714,6 +718,7 @@ export const GET_NOTIFICATIONS = gql`
         }
         reaction {
           id
+          kind
         }
       }
     }

--- a/src/types/graphql-global-types.ts
+++ b/src/types/graphql-global-types.ts
@@ -52,6 +52,7 @@
  * * SpaceFollowed
  * * SpaceUnfollowed
  * * SpaceOwnershipTransferAccepted
+ * * SpaceOwnershipTransferCreated
  * * AccountFollowed
  * * AccountUnfollowed
  * * ProfileUpdated
@@ -103,6 +104,7 @@ export enum EventName {
   SpaceCreated = 'SpaceCreated',
   SpaceFollowed = 'SpaceFollowed',
   SpaceOwnershipTransferAccepted = 'SpaceOwnershipTransferAccepted',
+  SpaceOwnershipTransferCreated = 'SpaceOwnershipTransferCreated',
   SpaceUnfollowed = 'SpaceUnfollowed',
   SpaceUpdated = 'SpaceUpdated',
   UserNameRegistered = 'UserNameRegistered',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,6 +19,7 @@ export type Activity = {
   blockNumber: string
   eventIndex: number
   event: EventsName
+  reactionKind?: ReactionType
   /** Account id. */
   followingId?: string
   spaceId?: string


### PR DESCRIPTION
# Problems
- When the account doesn't have any profile, account notification won't show anything (render null), while it should still render with the address.
- Currently any reaction event are using same upvote icon and wording. Now, the wording are changed and icon are like and dislike based on the reaction kind