### PR TITLE
Remove disabled isApiReady from auth button

### DIFF
--- a/src/components/auth/AuthButtons.tsx
+++ b/src/components/auth/AuthButtons.tsx
@@ -1,5 +1,4 @@
 import Button, { ButtonSize, ButtonType } from 'antd/lib/button'
-import { useSubsocialApi } from 'src/components/substrate/SubstrateContext'
 import { useAuth } from './AuthContext'
 import { useMyAccountsContext } from './MyAccountsContext'
 
@@ -23,14 +22,12 @@ export function OpenAuthButton({
   block = false,
   ghost = false,
 }: OpenAuthButton) {
-  const { isApiReady } = useSubsocialApi()
   const { openSignInModal } = useAuth()
 
   return (
     <Button
       size={size}
       className={className}
-      disabled={!isApiReady}
       type={type}
       block={block}
       ghost={ghost}


### PR DESCRIPTION
This auth button doesn't need the api ready to work

Related to https://app.clickup.com/t/861mevubm