### PR TITLE
Fix refresh token issue

### DIFF
--- a/src/components/onboarding/contexts/IsProxyAdded.tsx
+++ b/src/components/onboarding/contexts/IsProxyAdded.tsx
@@ -16,6 +16,7 @@ export function IsProxyAddedProvider({ children }: { children: any }) {
     parseStorageToState: data => data === '1',
     parseStateToStorage: state => (state ? '1' : undefined),
     storageKeyType: 'user',
+    subscribe: true,
   })
 
   return (

--- a/src/components/utils/OffchainSigner/ExternalStorage.ts
+++ b/src/components/utils/OffchainSigner/ExternalStorage.ts
@@ -60,6 +60,7 @@ const signOutFromProxy = (address: string) => {
   localStorage.removeItem(createStorageKeyWithSubAddress(SIGNER_TOKEN_KEY, address))
   localStorage.removeItem(createStorageKeyWithSubAddress(SIGNER_REFRESH_TOKEN_KEY, address))
   localStorage.removeItem(createStorageKeyWithSubAddress(SIGNER_PROXY_ADDED, address))
+  window.dispatchEvent(new Event('storage'))
 }
 
 export {

--- a/src/components/utils/OffchainSigner/ExternalStorage.ts
+++ b/src/components/utils/OffchainSigner/ExternalStorage.ts
@@ -55,6 +55,13 @@ const isProxyAdded = (myAddress: string) =>
     ? true
     : false
 
+const signOutFromProxy = (address: string) => {
+  localStorage.removeItem(createStorageKeyWithSubAddress(SIGNER_ADDRESS_KEY, address))
+  localStorage.removeItem(createStorageKeyWithSubAddress(SIGNER_TOKEN_KEY, address))
+  localStorage.removeItem(createStorageKeyWithSubAddress(SIGNER_REFRESH_TOKEN_KEY, address))
+  localStorage.removeItem(createStorageKeyWithSubAddress(SIGNER_PROXY_ADDED, address))
+}
+
 export {
   SIGNER_ADDRESS_KEY,
   SIGNER_TOKEN_KEY,
@@ -76,4 +83,5 @@ export {
   getCurrentEmailAddress,
   getSignerEmailAddress,
   isProxyAdded,
+  signOutFromProxy,
 }

--- a/src/components/utils/OffchainSigner/api/axios.ts
+++ b/src/components/utils/OffchainSigner/api/axios.ts
@@ -8,6 +8,7 @@ import {
   getSignerToken,
   SIGNER_REFRESH_TOKEN_KEY,
   SIGNER_TOKEN_KEY,
+  signOutFromProxy,
 } from '../ExternalStorage'
 import { callRefreshToken } from './requests'
 import { OffchainSignerEndpoint } from './utils'
@@ -43,6 +44,13 @@ const offchainSignerApi = () => {
       const isRefreshTokenRequest = originalRequestUrl?.includes(
         OffchainSignerEndpoint.REFRESH_TOKEN,
       )
+      if (isRefreshTokenRequest) {
+        const address = readMyAddress()
+        if (address) {
+          signOutFromProxy(address)
+        }
+        throw new Error('Your session has expired, please approve your popup removal again.')
+      }
 
       try {
         // If the error is due to an expired access token and a refresh token is available

--- a/src/components/utils/OffchainSigner/api/axios.ts
+++ b/src/components/utils/OffchainSigner/api/axios.ts
@@ -10,6 +10,7 @@ import {
   SIGNER_TOKEN_KEY,
 } from '../ExternalStorage'
 import { callRefreshToken } from './requests'
+import { OffchainSignerEndpoint } from './utils'
 
 const { offchainSignerUrl } = config
 
@@ -38,13 +39,19 @@ const offchainSignerApi = () => {
       const address = readMyAddress()
       const refreshToken = getSignerRefreshToken(address!)
 
+      const originalRequestUrl = originalRequest.baseURL || originalRequest.url
+      const isRefreshTokenRequest = originalRequestUrl?.includes(
+        OffchainSignerEndpoint.REFRESH_TOKEN,
+      )
+
       try {
         // If the error is due to an expired access token and a refresh token is available
         if (
           error.response.status === 401 &&
           originalRequest &&
           !originalRequest._retry &&
-          refreshToken
+          refreshToken &&
+          !isRefreshTokenRequest
         ) {
           originalRequest._retry = true
 

--- a/src/components/utils/OffchainSigner/api/utils.ts
+++ b/src/components/utils/OffchainSigner/api/utils.ts
@@ -77,7 +77,7 @@ const wrappedRequest = ({ backEndUrl, method, config, data }: WrappedRequestProp
 export const sendRequest = async ({ request, onFailedText }: SendRequestProps) => {
   try {
     const res = await request()
-    if (res.status !== 200) {
+    if (!res.status.toString().startsWith('2')) {
       log.warn(onFailedText)
     }
 


### PR DESCRIPTION
# Issue
When your refresh token is expired, it will try to refresh it infinitely, until it got rate limited.

# Solution
Fix the infinite fetching, and logs the proxy out when the refresh token expired.