### PR TITLE
Fix issue where super like data not fetched from server side

### DIFF
--- a/src/rtk/features/posts/postsSlice.ts
+++ b/src/rtk/features/posts/postsSlice.ts
@@ -232,6 +232,7 @@ export const fetchPosts = createAsyncThunk<PostStruct[], FetchPostsArgs, ThunkAp
     handleAfterDataFetch: async (entities, args, { dispatch }) => {
       const {
         api,
+        newIds,
         withContent = true,
         withOwner = true,
         withSpace = true,
@@ -244,7 +245,11 @@ export const fetchPosts = createAsyncThunk<PostStruct[], FetchPostsArgs, ThunkAp
         entities,
       )
 
-      const fetches: Promise<any>[] = []
+      const fetches: Promise<any>[] = [
+        dispatch(fetchSuperLikeCounts({ postIds: newIds as string[] })),
+        dispatch(fetchPostRewards({ postIds: newIds as string[] })),
+        dispatch(fetchCanPostsSuperLiked({ postIds: newIds as string[] })),
+      ]
 
       if (withOwner) {
         const ids = getUniqueOwnerIds(entities)
@@ -339,9 +344,6 @@ export const fetchPosts = createAsyncThunk<PostStruct[], FetchPostsArgs, ThunkAp
             dataSource,
           }),
         )
-      dispatch(fetchSuperLikeCounts({ postIds: newIds }))
-      dispatch(fetchPostRewards({ postIds: newIds }))
-      dispatch(fetchCanPostsSuperLiked({ postIds: newIds }))
 
       withReactionByAccount &&
         dispatch(fetchAddressLikeCounts({ postIds: newIds, address: withReactionByAccount }))


### PR DESCRIPTION
# Issue
we fetch super like data from `fetchPosts` thunk, and in there, we don't await the fetch call
so it might not be fetched if we call `fetchPosts` from server side as the response is sent first before the request finished