### PR TITLE
Fix Domain Issue

### DIFF
--- a/src/components/auth/signIn/email/ConfirmationModalContent.tsx
+++ b/src/components/auth/signIn/email/ConfirmationModalContent.tsx
@@ -1,4 +1,4 @@
-import { isStr, toSubsocialAddress } from '@subsocial/utils'
+import { isStr } from '@subsocial/utils'
 import { Button, Form } from 'antd'
 import clsx from 'clsx'
 import jwtDecode from 'jwt-decode'
@@ -18,6 +18,7 @@ import {
 } from 'src/components/utils/OffchainSigner/ExternalStorage'
 import { CODE_DIGIT } from 'src/config/ValidationsConfig'
 import useSignerExternalStorage from 'src/hooks/useSignerExternalStorage'
+import { convertToSubsocialAddress } from 'src/utils/address'
 import { StepsEnum } from '../../AuthContext'
 import styles from './SignInModalContent.module.sass'
 import { RegexValidations, useFormValidation } from './useFormValidation'
@@ -36,7 +37,7 @@ type Props = {
 
 const ConfirmationModalContent = ({ setCurrentStep }: Props) => {
   const userAddress = getTempRegisterAccount()
-  const subsocialAddress = toSubsocialAddress(userAddress)
+  const subsocialAddress = convertToSubsocialAddress(userAddress)
   const { isMobile } = useResponsiveSize()
 
   const [error, setError] = useState<string | null>(null)

--- a/src/components/common/inputs/SelectAccountInput.tsx
+++ b/src/components/common/inputs/SelectAccountInput.tsx
@@ -1,12 +1,13 @@
 import { GenericAccountId } from '@polkadot/types'
 import registry from '@subsocial/api/utils/registry'
-import { isDef, isEmptyArray, toSubsocialAddress } from '@subsocial/utils'
+import { isDef, isEmptyArray } from '@subsocial/utils'
 import { Select } from 'antd'
 import clsx from 'clsx'
 import { useEffect, useState } from 'react'
 import { useMyAccounts } from 'src/components/auth/MyAccountsContext'
 import { equalAddresses } from 'src/components/substrate'
 import { useSelectProfile } from 'src/rtk/app/hooks'
+import { convertToSubsocialAddress } from 'src/utils/address'
 import { SelectAddressPreview } from '../../profile-selector/MyAccountMenu'
 import Avatar from '../../profiles/address-views/Avatar'
 import styles from './inputs.module.sass'
@@ -55,9 +56,7 @@ export const SelectAccountInput = ({
   disabled,
 }: SelectAccountInputProps) => {
   const { accounts, status } = useMyAccounts()
-  const allExtensionAccounts = accounts
-    .map(x => x.address && (toSubsocialAddress(x.address) as string))
-    .filter(isDef)
+  const allExtensionAccounts = accounts.map(x => convertToSubsocialAddress(x.address)).filter(isDef)
 
   const [defaultOptions, setDefaultOptions] = useState<any[]>([])
   const [selectOptions, setSelectOptions] = useState<any[]>(defaultOptions)

--- a/src/components/domains/manage/DomainManageModal.tsx
+++ b/src/components/domains/manage/DomainManageModal.tsx
@@ -17,7 +17,7 @@ import { useMyAddress } from '../../auth/MyAccountsContext'
 import useSubstrate from '../../substrate/useSubstrate'
 import { Loading } from '../../utils'
 import { ButtonLink } from '../../utils/CustomLinks'
-import { MutedDiv } from '../../utils/MutedText';
+import { MutedDiv } from '../../utils/MutedText'
 import SelectSpacePreview from '../../utils/SelectSpacePreview'
 import TxButton from '../../utils/TxButton'
 import styles from '../index.module.sass'
@@ -74,7 +74,9 @@ const ManageDomainMenu: FC<ManageDomainStepProps> = ({ domainStruct }) => {
   return (
     <>
       <Row justify='center'>
-        <div className={clsx('SubsocialGradient', styles.MenuModalDomainTitle)}>{domainStruct.id}</div>
+        <div className={clsx('SubsocialGradient', styles.MenuModalDomainTitle)}>
+          {domainStruct.id}
+        </div>
       </Row>
       {/*<DomainExpireAt domainStruct={domainStruct} />*/}
       <div className='mt-3 mb-2'>You can use your domain as:</div>
@@ -149,6 +151,13 @@ const SpaceUsername: FC<ManageDomainStepProps> = ({ domainStruct }) => {
   const defaultInnerSpace = domainStruct?.innerSpace?.toString()
 
   const [innerValue, setInnerValue] = useState<string | undefined>(defaultInnerSpace)
+  useEffect(() => {
+    if (mySpaceIds.length > 0)
+      setInnerValue(prev => {
+        if (prev) return prev
+        return mySpaceIds?.[0]
+      })
+  }, [mySpaceIds])
 
   const domain = domainStruct.id
 
@@ -326,7 +335,9 @@ const Success: FC<ManageDomainStepProps> = ({ domainStruct }) => {
           text='Your domain is registered!'
           className={clsx(styles.ModalTitle)}
         />
-        <MutedDiv className={styles.ModalSubtitle}>Your profile is ready to use, and you can edit it at any time.</MutedDiv>
+        <MutedDiv className={styles.ModalSubtitle}>
+          Your profile is ready to use, and you can edit it at any time.
+        </MutedDiv>
       </Row>
       <Row justify='center'>
         <div className={clsx('SubsocialGradient', styles.ModalDomainTitle)}>{domain}</div>
@@ -381,7 +392,7 @@ export const ManageDomainModal = ({ domain, close, visible }: ManageDomainModalP
       className={clsx(styles.Modal, 'DfSignInModal')}
       closable={false}
       title={null}
-      width={currentStep === 'success' ? 520: 620}
+      width={currentStep === 'success' ? 520 : 620}
       onCancel={close}
       visible={visible}
       footer={null}

--- a/src/components/donate/DonateModal.tsx
+++ b/src/components/donate/DonateModal.tsx
@@ -1,4 +1,4 @@
-import { balanceWithDecimal, isDef, toSubsocialAddress } from '@subsocial/utils'
+import { balanceWithDecimal, isDef } from '@subsocial/utils'
 import { Avatar, Col, Form, FormInstance, Row, Select } from 'antd'
 import BN from 'bignumber.js'
 import clsx from 'clsx'
@@ -13,6 +13,7 @@ import BaseAvatar from 'src/components/utils/DfAvatar'
 import { showSuccessMessage } from 'src/components/utils/Message'
 import { MutedDiv, MutedSpan } from 'src/components/utils/MutedText'
 import { useChainInfo } from 'src/rtk/features/chainsInfo/chainsInfoHooks'
+import { convertToSubsocialAddress } from 'src/utils/address'
 import { useSelectProfile } from '../../rtk/features/profiles/profilesHooks'
 import { TipAmountInput } from './AmountInput'
 import { useTipContext } from './DonateModalContext'
@@ -106,10 +107,10 @@ export const DonateCard = ({ recipientAddress }: DonateProps) => {
     state: { accounts },
   } = useMyAccountsContext()
 
-  const mySubsocialAddress = toSubsocialAddress(addressFromUrl)
+  const mySubsocialAddress = convertToSubsocialAddress(addressFromUrl)
 
   const accountsForChoosing = accounts
-    .filter(x => toSubsocialAddress(x.address) !== mySubsocialAddress)
+    .filter(x => convertToSubsocialAddress(x.address) !== mySubsocialAddress)
     .map(x => x.address)
 
   const ss58Format = infoByNetwork?.ss58Format

--- a/src/components/profile-selector/AccountSelector.tsx
+++ b/src/components/profile-selector/AccountSelector.tsx
@@ -8,13 +8,14 @@ import { ProfilePreviewByAccountId, SelectAddressPreview } from '../profiles/add
 import SubTitle from '../utils/SubTitle'
 
 import { asAccountId } from '@subsocial/api'
-import { isEmptyArray, toSubsocialAddress } from '@subsocial/utils'
+import { isEmptyArray } from '@subsocial/utils'
 import config from 'src/config'
 import { isMobileDevice } from 'src/config/Size.config'
 import { useSelectProfile } from 'src/rtk/app/hooks'
 import { useAppDispatch } from 'src/rtk/app/store'
 import { fetchProfileSpaces } from 'src/rtk/features/profiles/profilesSlice'
 import { AccountId, DataSourceTypes } from 'src/types'
+import { convertToSubsocialAddress } from 'src/utils/address'
 import { useSubstrate } from '../substrate/useSubstrate'
 import { Loading } from '../utils'
 import { ActionMenu } from './ActionMenu'
@@ -234,7 +235,8 @@ export const AccountSelector = ({
   const { setCurrentStep } = useAuth()
 
   const excludeCurrentEmailAccounts = emailAccounts.filter(account => {
-    const walletAddress = toSubsocialAddress(account.accountAddress) ?? account.accountAddress
+    const walletAddress =
+      convertToSubsocialAddress(account.accountAddress) ?? account.accountAddress
     if (walletAddress !== currentAddress) return account
     return
   })

--- a/src/components/profiles/ViewProfile.tsx
+++ b/src/components/profiles/ViewProfile.tsx
@@ -1,6 +1,6 @@
 import { PlusOutlined } from '@ant-design/icons'
 import { AccountId } from '@polkadot/types/interfaces'
-import { isEmptyStr, toSubsocialAddress } from '@subsocial/utils'
+import { isEmptyStr } from '@subsocial/utils'
 import { Button } from 'antd'
 import { NextPage } from 'next'
 import dynamic from 'next/dynamic'
@@ -33,6 +33,7 @@ import { Donate } from 'src/components/donate'
 import { isBlockedAccount } from 'src/moderation'
 import { useFetchSpaceIdsByFollower } from 'src/rtk/app/hooks'
 import { fetchEntityOfSpaceIdsByFollower } from 'src/rtk/features/spaceIds/followedSpaceIdsSlice'
+import { convertToSubsocialAddress } from 'src/utils/address'
 import { useAppSelector } from '../../rtk/app/store'
 import { useSelectProfile } from '../../rtk/features/profiles/profilesHooks'
 import { fetchSpaceIdsOwnedByAccount } from '../../rtk/features/spaceIds/ownSpaceIdsSlice'
@@ -215,7 +216,7 @@ getInitialPropsWithRedux(ProfilePage, async ({ context, subsocial, dispatch, red
 
   const addressStr = address as string
 
-  const subsocialAddress = toSubsocialAddress(addressStr)
+  const subsocialAddress = convertToSubsocialAddress(addressStr)
   if (subsocialAddress !== addressStr) {
     if (req) {
       res?.writeHead(301, {

--- a/src/components/utils/OffchainSigner/ExternalStorage.ts
+++ b/src/components/utils/OffchainSigner/ExternalStorage.ts
@@ -1,4 +1,4 @@
-import { toSubsocialAddress } from '@subsocial/utils'
+import { convertToSubsocialAddress } from 'src/utils/address'
 import { createStorageKey } from 'src/utils/storage'
 import store from 'store'
 
@@ -14,7 +14,7 @@ const SIGNER_EMAIL_ADDRESS_KEY = 'SignerEmailAddress'
 const SIGNER_PROXY_ADDED = 'SignerProxyAdded'
 
 export const createStorageKeyWithSubAddress = (key: string, myAddress: string) => {
-  const subsocialAddress = toSubsocialAddress(myAddress)
+  const subsocialAddress = convertToSubsocialAddress(myAddress)
   return createStorageKey(key, subsocialAddress!)
 }
 
@@ -30,7 +30,7 @@ const getTempRegisterAccount = (): string | undefined =>
   store.get(createStorageKey(TEMP_REGISTER_ACCOUNT))
 
 const isCurrentSignerAddress = (myAddress: string) =>
-  store.get(createStorageKey(SIGNER_ADDRESS_KEY, toSubsocialAddress(myAddress))) === 1
+  store.get(createStorageKey(SIGNER_ADDRESS_KEY, convertToSubsocialAddress(myAddress))) === 1
     ? true
     : false
 const getProxyAddress = (myAddress: string): string | undefined =>
@@ -48,7 +48,7 @@ const getSaltByAddress = (myAddress: string): string | undefined =>
   store.get(createStorageKeyWithSubAddress(SALT, myAddress))
 
 const isProxyAdded = (myAddress: string) =>
-  store.get(createStorageKey(SIGNER_PROXY_ADDED, toSubsocialAddress(myAddress))) === 1
+  store.get(createStorageKey(SIGNER_PROXY_ADDED, convertToSubsocialAddress(myAddress))) === 1
     ? true
     : false
 

--- a/src/components/utils/OffchainSigner/SignerKeyringManager.ts
+++ b/src/components/utils/OffchainSigner/SignerKeyringManager.ts
@@ -1,6 +1,7 @@
 import { Keyring } from '@polkadot/api'
 import { hexToU8a, stringToU8a, u8aToHex, u8aToString } from '@polkadot/util'
 import { keccakAsU8a, naclDecrypt, naclEncrypt } from '@polkadot/util-crypto'
+import { convertToSubsocialAddress } from 'src/utils/address'
 
 const SALT_LENGTH = 32
 const HEX_CONSTANT = '0x80001f'
@@ -37,7 +38,6 @@ class SignerKeyringManager {
 
   public async generateAccount(seed: string) {
     const { sr25519PairFromSeed, mnemonicToMiniSecret } = await import('@polkadot/util-crypto')
-    const { toSubsocialAddress } = await import('@subsocial/utils')
 
     const miniSecret = mnemonicToMiniSecret(seed)
     const { publicKey: publicKeyBuffer } = sr25519PairFromSeed(miniSecret)
@@ -45,7 +45,7 @@ class SignerKeyringManager {
     const publicKey = u8aToHex(publicKeyBuffer)
     const secretKey = u8aToHex(miniSecret)
 
-    return { publicAddress: toSubsocialAddress(publicKey)!, secretKey }
+    return { publicAddress: convertToSubsocialAddress(publicKey)!, secretKey }
   }
 
   public encryptKey(key: string, password: string) {

--- a/src/hooks/useEmailAccount.ts
+++ b/src/hooks/useEmailAccount.ts
@@ -1,8 +1,8 @@
-import { toSubsocialAddress } from '@subsocial/utils'
 import jwtDecode from 'jwt-decode'
 import { JwtPayload } from 'src/components/utils/OffchainSigner/api/requests'
 import { SIGNER_TOKEN_KEY } from 'src/components/utils/OffchainSigner/ExternalStorage'
 import { EmailAccount } from 'src/types'
+import { convertToSubsocialAddress } from 'src/utils/address'
 import { isExpExpired } from 'src/utils/token'
 import store from 'store'
 
@@ -17,7 +17,7 @@ const useEmailAccount = () => {
         if (!emailVerified || isExpired) return
 
         const result = {
-          accountAddress: toSubsocialAddress(accountAddress) ?? accountAddress,
+          accountAddress: convertToSubsocialAddress(accountAddress) ?? accountAddress,
           email,
         }
 

--- a/src/hooks/useSignerExternalStorage.ts
+++ b/src/hooks/useSignerExternalStorage.ts
@@ -1,4 +1,3 @@
-import { toSubsocialAddress } from '@subsocial/utils'
 import {
   PROXY_ADDRESS_KEY,
   SIGNER_ADDRESS_KEY,
@@ -8,6 +7,7 @@ import {
   SIGNER_TOKEN_KEY,
   TEMP_REGISTER_ACCOUNT,
 } from 'src/components/utils/OffchainSigner/ExternalStorage'
+import { convertToSubsocialAddress } from 'src/utils/address'
 import useExternalStorage from './useExternalStorage'
 
 type Props = {
@@ -38,42 +38,42 @@ const useSignerExternalStorage = () => {
     storageKeyType: 'user',
   })
 
-  const convertToSubsocialAddress = (userAddress: string) => {
-    const subsocialAddress = toSubsocialAddress(userAddress)
+  const toSubsocialAddress = (userAddress: string) => {
+    const subsocialAddress = convertToSubsocialAddress(userAddress)
     if (!subsocialAddress) console.warn('Unable to define subsocial address')
 
     return subsocialAddress
   }
 
   const setSignerTokensByAddress = ({ userAddress, token, refreshToken }: Props) => {
-    const subsocialAddress = convertToSubsocialAddress(userAddress)
+    const subsocialAddress = toSubsocialAddress(userAddress)
     setSignerToken(token, subsocialAddress!)
     setSignerRefreshToken(refreshToken, subsocialAddress!)
   }
 
   const setSignerTempRegisterAccount = (userAddress: string) => {
-    const subsocialAddress = convertToSubsocialAddress(userAddress)
+    const subsocialAddress = toSubsocialAddress(userAddress)
     setTempRegisterAccount(subsocialAddress)
   }
 
   const setSignerProxyAddress = (proxyAddress: string, userAddress: string) => {
-    const subsocialAddress = convertToSubsocialAddress(userAddress)
+    const subsocialAddress = toSubsocialAddress(userAddress)
     setProxyAddress(proxyAddress, subsocialAddress)
   }
 
   const setSignerEmailAddress = (emailAddress: string, userAddress: string) => {
-    const subsocialAddress = convertToSubsocialAddress(userAddress)
+    const subsocialAddress = toSubsocialAddress(userAddress)
     setEmailAddress(emailAddress, subsocialAddress)
   }
 
   const setSignerProxyAdded = (state: 'enabled' | 'disabled', userAddress: string) => {
-    const subsocialAddress = convertToSubsocialAddress(userAddress)
+    const subsocialAddress = toSubsocialAddress(userAddress)
     const data = state === 'enabled' ? true : undefined
     setProxyAdded(data, subsocialAddress)
   }
 
   const setIsSignerAddress = (userAddress: string) => {
-    const subsocialAddress = convertToSubsocialAddress(userAddress)
+    const subsocialAddress = toSubsocialAddress(userAddress)
     setSignerAddress(true, subsocialAddress)
   }
 

--- a/src/rtk/features/accounts/myAccountSlice.ts
+++ b/src/rtk/features/accounts/myAccountSlice.ts
@@ -1,9 +1,10 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
-import { nonEmptyStr, toSubsocialAddress } from '@subsocial/utils'
+import { nonEmptyStr } from '@subsocial/utils'
 import { equalAddresses } from 'src/components/substrate'
 import { CURRENT_EMAIL_ADDRESS } from 'src/components/utils/OffchainSigner/ExternalStorage'
 import { isBlockedAccount } from 'src/moderation'
 import { AccountId } from 'src/types'
+import { convertToSubsocialAddress } from 'src/utils/address'
 import store from 'store'
 
 const MY_EMAIL_ADDRESS = 'df.myEmailAddress'
@@ -76,7 +77,7 @@ const myAccountSlice = createSlice({
       }
     },
     setMyAddress(state, action: PayloadAction<AccountId>) {
-      const address = toSubsocialAddress(action.payload)
+      const address = convertToSubsocialAddress(action.payload)
 
       if (address && !equalAddresses(state.address, address)) {
         storeMyAddress(address)

--- a/src/rtk/features/domainPendingOrders/utils.ts
+++ b/src/rtk/features/domainPendingOrders/utils.ts
@@ -1,8 +1,9 @@
 import { EntityId } from '@reduxjs/toolkit'
-import { isDef, isEmptyArray, toSubsocialAddress } from '@subsocial/utils'
+import { isDef, isEmptyArray } from '@subsocial/utils'
 import { DocumentNode } from 'graphql'
 import { sellerSquidGraphQlClient } from 'src/components/domains/dot-seller/config'
 import { RootState } from 'src/rtk/app/rootReducer'
+import { convertToSubsocialAddress } from 'src/utils/address'
 import {
   ordersAdapter,
   PendingDomainEntity,
@@ -46,9 +47,9 @@ export const getOrders = async ({
 
     return {
       ...order,
-      target: toSubsocialAddress(target) || '',
-      signer: toSubsocialAddress(signer) || '',
-      createdByAccount: toSubsocialAddress(createdByAccount) || '',
+      target: convertToSubsocialAddress(target) || '',
+      signer: convertToSubsocialAddress(signer) || '',
+      createdByAccount: convertToSubsocialAddress(createdByAccount) || '',
     }
   })
 

--- a/src/rtk/features/profiles/profilesSlice.ts
+++ b/src/rtk/features/profiles/profilesSlice.ts
@@ -1,6 +1,5 @@
 import { createAsyncThunk, createEntityAdapter, createSlice, EntityId } from '@reduxjs/toolkit'
 import { SubsocialApi } from '@subsocial/api'
-import { toSubsocialAddress } from '@subsocial/utils'
 import { getProfilesData } from 'src/graphql/apis'
 import { ProfileFragmentMapped } from 'src/graphql/apis/types'
 import {
@@ -18,6 +17,7 @@ import {
   generatePrefetchDataFn,
 } from 'src/rtk/app/wrappers'
 import { ProfileSpaceIdByAccount, SpaceStruct } from 'src/types'
+import { convertToSubsocialAddress } from 'src/utils/address'
 import { fetchSpaces } from '../spaces/spacesSlice'
 
 const profileSpacesAdapter = createEntityAdapter<ProfileSpaceIdByAccount>()
@@ -49,7 +49,7 @@ export const selectProfileSpace = (
   state: RootState,
   id: EntityId,
 ): ProfileSpaceIdByAccount | undefined => {
-  const subsocialAddress = toSubsocialAddress(id.toString())
+  const subsocialAddress = convertToSubsocialAddress(id.toString())
 
   if (!subsocialAddress) return undefined
 

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -1,5 +1,6 @@
 import { decodeAddress, encodeAddress as encodePolkadotAddress } from '@polkadot/keyring'
 import { hexToU8a, isHex } from '@polkadot/util'
+import { toSubsocialAddress } from '@subsocial/utils'
 
 export function isValidAddress(address: string) {
   try {
@@ -7,5 +8,16 @@ export function isValidAddress(address: string) {
     return true
   } catch (error) {
     return false
+  }
+}
+
+export function convertToSubsocialAddress(address?: string) {
+  if (!address) return address
+
+  try {
+    const subsocialAddress = toSubsocialAddress(address)
+    return subsocialAddress
+  } catch {
+    return undefined
   }
 }


### PR DESCRIPTION
- When selecting space for domain, in the UI it preselected as your first space, but in the state itself, its still empty, so the user will set their domain space to '0', which is wrong. Solution: set default state to their first space
- When user connected their talisman wallet with all of their account (including EVM), evm addresses will cause error when calling `toSubsocialAddress`. Solution: add helper to wrap `toSubsocialAddress` with try catch, and change all usage of `toSubsocialAddress` to `convertToSubsocialAddress`