### PR TITLE
Fix query cache issue

### DIFF
--- a/src/components/activity/AccountActivity.tsx
+++ b/src/components/activity/AccountActivity.tsx
@@ -12,6 +12,7 @@ import {
   useGetReactionActivities,
   useGetTweetActivities,
 } from 'src/graphql/hooks'
+import WriteSomething from '../posts/WriteSomething'
 import { Loading } from '../utils'
 import { createLoadMorePosts, FeedActivities } from './FeedActivities'
 import { createLoadMoreActivities, NotifActivities } from './Notifications'
@@ -115,7 +116,7 @@ const activityTabs = [
   'spaces',
   'all',
 ] as const
-type ActivityTab = typeof activityTabs[number]
+type ActivityTab = (typeof activityTabs)[number]
 const getTab = (tab: ActivityTab) => tab
 const OffchainAccountActivity = ({ address }: ActivitiesByAddressProps) => {
   const getActivityCounts = useGetActivityCounts()
@@ -172,7 +173,10 @@ const OffchainAccountActivity = ({ address }: ActivitiesByAddressProps) => {
   return (
     <Tabs activeKey={activeTab} onChange={onChangeTab}>
       <TabPane tab={getTabTitle('Posts', postsCount)} key={getTab('posts')}>
-        <PostActivities address={address} totalCount={postsCount} />
+        <div className='d-flex flex-column mt-3'>
+          <WriteSomething />
+          <PostActivities address={address} totalCount={postsCount} />
+        </div>
       </TabPane>
       {(tweetsCount > 0 || haveDisplayedTweetsTab) && (
         <TabPane tab={getTabTitle('Tweets', tweetsCount)} key={getTab('tweets')}>

--- a/src/components/activity/AccountActivity.tsx
+++ b/src/components/activity/AccountActivity.tsx
@@ -12,6 +12,7 @@ import {
   useGetReactionActivities,
   useGetTweetActivities,
 } from 'src/graphql/hooks'
+import { useIsMyAddress } from '../auth/MyAccountsContext'
 import WriteSomething from '../posts/WriteSomething'
 import { Loading } from '../utils'
 import { createLoadMorePosts, FeedActivities } from './FeedActivities'
@@ -119,6 +120,7 @@ const activityTabs = [
 type ActivityTab = (typeof activityTabs)[number]
 const getTab = (tab: ActivityTab) => tab
 const OffchainAccountActivity = ({ address }: ActivitiesByAddressProps) => {
+  const isMyAddress = useIsMyAddress(address)
   const getActivityCounts = useGetActivityCounts()
   const router = useRouter()
   const [activeTab, setActiveTab] = useState<ActivityTab>('posts')
@@ -173,10 +175,14 @@ const OffchainAccountActivity = ({ address }: ActivitiesByAddressProps) => {
   return (
     <Tabs activeKey={activeTab} onChange={onChangeTab}>
       <TabPane tab={getTabTitle('Posts', postsCount)} key={getTab('posts')}>
-        <div className='d-flex flex-column mt-3'>
-          <WriteSomething />
+        {isMyAddress ? (
+          <div className='d-flex flex-column mt-3'>
+            <WriteSomething />
+            <PostActivities address={address} totalCount={postsCount} />
+          </div>
+        ) : (
           <PostActivities address={address} totalCount={postsCount} />
-        </div>
+        )}
       </TabPane>
       {(tweetsCount > 0 || haveDisplayedTweetsTab) && (
         <TabPane tab={getTabTitle('Tweets', tweetsCount)} key={getTab('tweets')}>

--- a/src/components/utils/datahub/active-staking.ts
+++ b/src/components/utils/datahub/active-staking.ts
@@ -49,6 +49,7 @@ export async function getSuperLikeCounts(postIds: string[]): Promise<SuperLikeCo
   >({
     query: GET_SUPER_LIKE_COUNTS,
     variables: { postIds },
+    fetchPolicy: 'network-only',
   })
 
   const resultMap = new Map<string, SuperLikeCount>()
@@ -124,6 +125,7 @@ export async function getAddressLikeCountToPosts(
   >({
     query: GET_ADDRESS_LIKE_COUNT_TO_POSTS,
     variables: { postIds, address },
+    fetchPolicy: 'network-only',
   })
 
   const resultMap = new Map<string, AddressLikeCount>()
@@ -212,6 +214,7 @@ export async function getRewardReport(address: string): Promise<RewardReport> {
   >({
     query: GET_REWARD_REPORT,
     variables: { address, ...getDayAndWeekTimestamp() },
+    fetchPolicy: 'network-only',
   })
   const weekReward = res.data.activeStakingRewardsByWeek?.[0]
 

--- a/src/components/utils/datahub/active-staking.ts
+++ b/src/components/utils/datahub/active-staking.ts
@@ -17,7 +17,7 @@ import { PostRewards } from 'src/rtk/features/activeStaking/postRewardSlice'
 import { RewardHistory } from 'src/rtk/features/activeStaking/rewardHistorySlice'
 import { fetchRewardReport, RewardReport } from 'src/rtk/features/activeStaking/rewardReportSlice'
 import {
-  fetchSuperLikeCounts,
+  invalidateSuperLikeCounts,
   SuperLikeCount,
 } from 'src/rtk/features/activeStaking/superLikeCountsSlice'
 import {
@@ -395,7 +395,7 @@ async function processSubscriptionEvent(
   const dispatch = getStoreDispatcher()
   if (!dispatch) throw new Error('Dispatcher not exist')
 
-  dispatch(fetchSuperLikeCounts({ postIds: [post.persistentId], reload: true }))
+  dispatch(invalidateSuperLikeCounts({ postId: post.persistentId }))
   if (staker.id === myAddress) {
     dispatch(fetchRewardReport({ address: myAddress, reload: true }))
     dispatch(

--- a/src/components/utils/datahub/utils.ts
+++ b/src/components/utils/datahub/utils.ts
@@ -19,6 +19,7 @@ import ws from 'isomorphic-ws'
 import { datahubQueryUrl, datahubSubscriptionUrl } from 'src/config/env'
 import { createApolloClient } from 'src/graphql/client'
 import { wait } from 'src/utils/promise'
+import { isServerSide } from '..'
 
 dayjs.extend(utc)
 dayjs.extend(isoWeek)
@@ -53,6 +54,9 @@ export function datahubQueryRequest<T, TVariables extends OperationVariables>(
   config: QueryOptions<TVariables, T>,
 ) {
   const client = getApolloClient()
+  if (isServerSide()) {
+    config.fetchPolicy = 'no-cache'
+  }
   return client.query(config)
 }
 

--- a/src/graphql/client.ts
+++ b/src/graphql/client.ts
@@ -12,11 +12,8 @@ export function getApolloClient() {
   return apolloClient
 }
 
-export const createApolloClient = (
-  graphqlUrl: string,
-  defaultOptions?: DefaultOptions,
-): ApolloClient<NormalizedCacheObject> => {
-  let config: DefaultOptions = defaultOptions ?? {}
+export const createApolloClient = (graphqlUrl: string): ApolloClient<NormalizedCacheObject> => {
+  let config: DefaultOptions = {}
   if (isServerSide()) {
     config = {
       query: {

--- a/src/graphql/client.ts
+++ b/src/graphql/client.ts
@@ -12,8 +12,11 @@ export function getApolloClient() {
   return apolloClient
 }
 
-export const createApolloClient = (graphqlUrl: string): ApolloClient<NormalizedCacheObject> => {
-  let config: DefaultOptions = {}
+export const createApolloClient = (
+  graphqlUrl: string,
+  defaultOptions?: DefaultOptions,
+): ApolloClient<NormalizedCacheObject> => {
+  let config: DefaultOptions = defaultOptions ?? {}
   if (isServerSide()) {
     config = {
       query: {

--- a/src/rtk/features/activeStaking/superLikeCountsSlice.ts
+++ b/src/rtk/features/activeStaking/superLikeCountsSlice.ts
@@ -1,5 +1,6 @@
-import { createEntityAdapter, createSlice } from '@reduxjs/toolkit'
+import { createAsyncThunk, createEntityAdapter, createSlice } from '@reduxjs/toolkit'
 import { getSuperLikeCounts } from 'src/components/utils/datahub/active-staking'
+import { ThunkApiConfig } from 'src/rtk/app/helpers'
 import { RootState } from 'src/rtk/app/rootReducer'
 import { createSimpleManyFetchWrapper } from 'src/rtk/app/wrappers'
 
@@ -34,6 +35,16 @@ export const fetchSuperLikeCounts = createSimpleManyFetchWrapper<
     return { postIds: newPostIds }
   },
 })
+
+export const invalidateSuperLikeCounts = createAsyncThunk<void, { postId: string }, ThunkApiConfig>(
+  `${sliceName}/invalidate`,
+  async ({ postId }, { getState, dispatch }) => {
+    const state = selectPostSuperLikeCount(getState(), postId)
+    if (!state) return
+
+    await dispatch(fetchSuperLikeCounts({ postIds: [postId], reload: true }))
+  },
+)
 
 const slice = createSlice({
   name: sliceName,


### PR DESCRIPTION
# Main Problem
Currently the refetch done when user likes something is not performed correctly because it still uses data from cache instead of refetching the data, especially with the reward report

## Other fixes
- Only refetch super like count for a post (when there is an event) when the post is relevant to current state, if its not displayed anywhere, then it won't be refetched
- Add write something block to activity page