### PR TITLE
Improve Profile Page for Muted Accounts

### DIFF
--- a/src/components/activity/AccountActivity.tsx
+++ b/src/components/activity/AccountActivity.tsx
@@ -9,7 +9,6 @@ import {
   useGetCommentActivities,
   useGetFollowActivities,
   useGetPostActivities,
-  useGetReactionActivities,
   useGetTweetActivities,
 } from 'src/graphql/hooks'
 import { useIsMyAddress } from '../auth/MyAccountsContext'
@@ -33,6 +32,7 @@ const AllActivities = (props: BaseActivityProps) => {
   return (
     <NotifActivities
       {...props}
+      showMuted
       type='activities'
       loadMore={loadMoreActivities}
       noDataDesc='No activities yet'
@@ -41,19 +41,19 @@ const AllActivities = (props: BaseActivityProps) => {
   )
 }
 
-const ReactionActivities = (props: BaseActivityProps) => {
-  const getReactionActivities = useGetReactionActivities()
-  const loadMoreReactions = createLoadMoreActivities(getReactionActivities)
-  return (
-    <NotifActivities
-      {...props}
-      type='activities'
-      loadMore={loadMoreReactions}
-      noDataDesc='No reactions yet'
-      loadingLabel='Loading reactions...'
-    />
-  )
-}
+// const ReactionActivities = (props: BaseActivityProps) => {
+//   const getReactionActivities = useGetReactionActivities()
+//   const loadMoreReactions = createLoadMoreActivities(getReactionActivities)
+//   return (
+//     <NotifActivities
+//       {...props}
+//       type='activities'
+//       loadMore={loadMoreReactions}
+//       noDataDesc='No reactions yet'
+//       loadingLabel='Loading reactions...'
+//     />
+//   )
+// }
 
 const FollowActivities = (props: BaseActivityProps) => {
   const getFollowActivities = useGetFollowActivities()
@@ -61,6 +61,7 @@ const FollowActivities = (props: BaseActivityProps) => {
   return (
     <NotifActivities
       {...props}
+      showMuted
       type='activities'
       loadMore={loadMoreFollows}
       noDataDesc='No follows yet'
@@ -75,6 +76,7 @@ const CommentActivities = (props: BaseActivityProps) => {
   return (
     <FeedActivities
       {...props}
+      showMuted
       loadMore={loadMoreComments}
       noDataDesc='No comments yet'
       loadingLabel='Loading comments...'
@@ -88,6 +90,7 @@ const PostActivities = (props: BaseActivityProps) => {
   return (
     <FeedActivities
       {...props}
+      showMuted
       loadMore={loadMorePosts}
       noDataDesc='No posts yet'
       loadingLabel='Loading posts...'
@@ -101,6 +104,7 @@ const TweetActivities = (props: BaseActivityProps) => {
   return (
     <FeedActivities
       {...props}
+      showMuted
       loadMore={loadMorePosts}
       noDataDesc='No tweets yet'
       loadingLabel='Loading tweets...'
@@ -156,7 +160,7 @@ const OffchainAccountActivity = ({ address }: ActivitiesByAddressProps) => {
   const {
     postsCount,
     commentsCount,
-    reactionsCount,
+    // reactionsCount,
     followsCount,
     activitiesCount,
     spacesCount,
@@ -192,13 +196,13 @@ const OffchainAccountActivity = ({ address }: ActivitiesByAddressProps) => {
       <TabPane tab={getTabTitle('Comments', commentsCount)} key={getTab('comments')}>
         <CommentActivities address={address} totalCount={commentsCount} />
       </TabPane>
-      <TabPane
+      {/* <TabPane
         tab={getTabTitle('Reactions', reactionsCount)}
         key={getTab('reactions')}
         className={panePaddingClass}
       >
         <ReactionActivities address={address} totalCount={reactionsCount} />
-      </TabPane>
+      </TabPane> */}
       <TabPane
         tab={getTabTitle('Follows', followsCount)}
         key={getTab('follows')}

--- a/src/components/activity/FeedActivities.tsx
+++ b/src/components/activity/FeedActivities.tsx
@@ -41,12 +41,17 @@ export const createLoadMorePosts =
     return ids
   }
 
-export const FeedActivities = (props: ActivityProps<PostId>) => {
+export const FeedActivities = ({
+  showMuted,
+  ...props
+}: ActivityProps<PostId> & { showMuted?: boolean }) => {
   return (
     <InnerActivities
       {...props}
       getKey={postId => postId}
-      renderItem={(postId: PostId) => <PublicPostPreviewById postId={postId} />}
+      renderItem={(postId: PostId) => (
+        <PublicPostPreviewById postId={postId} showMuted={showMuted} />
+      )}
     />
   )
 }

--- a/src/components/activity/Notification.tsx
+++ b/src/components/activity/Notification.tsx
@@ -75,6 +75,7 @@ const NotificationMessage = ({
 
 type NotificationProps = Activity & {
   type: NotifActivitiesType
+  showMuted?: boolean
 }
 
 type InnerNotificationProps = NotificationProps &
@@ -208,8 +209,8 @@ const AccountNotification = (props: NotificationProps) => {
 }
 
 const PostNotification = (props: NotificationProps) => {
-  const { postId, event } = props
-  const postDetails = useSelectPost(postId)
+  const { postId, event, showMuted } = props
+  const postDetails = useSelectPost(postId, showMuted)
 
   let originalPostId = ''
   if (postDetails && postDetails.post.struct.isSharedPost) {
@@ -259,8 +260,8 @@ const PostNotification = (props: NotificationProps) => {
 }
 
 const CommentNotification = (props: NotificationProps) => {
-  const { commentId, event } = props
-  const commentDetails = useSelectPost(commentId)
+  const { commentId, event, showMuted } = props
+  const commentDetails = useSelectPost(commentId, showMuted)
 
   const rootPostId = commentDetails
     ? asCommentData(commentDetails.post)?.struct?.rootPostId
@@ -336,8 +337,8 @@ function getReactionType(
   }
 }
 const PostReactionNotification = (props: NotificationProps) => {
-  const { postId, reactionKind, event, type } = props
-  const postDetails = useSelectPost(postId)
+  const { postId, reactionKind, event, type, showMuted } = props
+  const postDetails = useSelectPost(postId, showMuted)
 
   if (!postDetails) return null
 
@@ -373,8 +374,8 @@ const PostReactionNotification = (props: NotificationProps) => {
 }
 
 const CommentReactionNotification = (props: NotificationProps) => {
-  const { commentId, event, reactionKind, type } = props
-  const commentDetails = useSelectPost(commentId)
+  const { commentId, event, reactionKind, type, showMuted } = props
+  const commentDetails = useSelectPost(commentId, showMuted)
 
   const rootPostId = commentDetails
     ? asCommentData(commentDetails.post)?.struct?.rootPostId

--- a/src/components/activity/Notifications.tsx
+++ b/src/components/activity/Notifications.tsx
@@ -15,14 +15,15 @@ export type NotifActivitiesType = 'notifications' | 'activities'
 
 type NotifActivitiesProps = ActivityProps<Activity> & {
   type: NotifActivitiesType
+  showMuted?: boolean
 }
 
-export const NotifActivities = ({ loadMore, type, ...props }: NotifActivitiesProps) => {
+export const NotifActivities = ({ loadMore, type, showMuted, ...props }: NotifActivitiesProps) => {
   return (
     <InnerActivities
       {...props}
       getKey={({ blockNumber, eventIndex }) => `${blockNumber}-${eventIndex}`}
-      renderItem={activity => <Notification type={type} {...activity} />}
+      renderItem={activity => <Notification type={type} showMuted={showMuted} {...activity} />}
       loadMore={loadMore}
     />
   )

--- a/src/components/posts/PublicPostPreview.tsx
+++ b/src/components/posts/PublicPostPreview.tsx
@@ -8,10 +8,11 @@ import { useShowLikeablePostsContext } from './ShowLikeablePostsContext'
 type Props = {
   postId: PostId
   showPinnedIcon?: boolean
+  showMuted?: boolean
 }
 
-export const PublicPostPreviewById = React.memo(({ postId, showPinnedIcon }: Props) => {
-  const post = useSelectPost(postId)
+export const PublicPostPreviewById = React.memo(({ postId, showPinnedIcon, showMuted }: Props) => {
+  const post = useSelectPost(postId, showMuted)
   const { value: showLikeablePostOnly } = useShowLikeablePostsContext()
   const { validByCreatorMinStake } = useCanPostSuperLiked(postId)
 

--- a/src/components/profiles/ViewProfile.tsx
+++ b/src/components/profiles/ViewProfile.tsx
@@ -1,7 +1,7 @@
 import { PlusOutlined } from '@ant-design/icons'
 import { AccountId } from '@polkadot/types/interfaces'
 import { isEmptyStr } from '@subsocial/utils'
-import { Button } from 'antd'
+import { Alert, Button } from 'antd'
 import { NextPage } from 'next'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
@@ -31,7 +31,7 @@ import { CopyAddress } from './address-views/utils'
 import router from 'next/router'
 import { Donate } from 'src/components/donate'
 import { isBlockedAccount } from 'src/moderation'
-import { useFetchSpaceIdsByFollower } from 'src/rtk/app/hooks'
+import { useFetchSpaceIdsByFollower, useIsMuted } from 'src/rtk/app/hooks'
 import { fetchEntityOfSpaceIdsByFollower } from 'src/rtk/features/spaceIds/followedSpaceIdsSlice'
 import { convertToSubsocialAddress } from 'src/utils/address'
 import { useAppSelector } from '../../rtk/app/store'
@@ -51,6 +51,8 @@ export type Props = {
 
 const Component = (props: Props) => {
   const { address, size = LARGE_AVATAR_SIZE } = props
+
+  const isMuted = useIsMuted(props.address.toString())
 
   const owner = useSelectProfile(address.toString()) || props.owner
   const profileSpaceByAccount = useAppSelector(state =>
@@ -105,8 +107,9 @@ const Component = (props: Props) => {
     )
 
   return (
-    <Section outerClassName='d-flex mb-2'>
-      <div className='d-flex'>
+    <Section outerClassName='mb-2'>
+      <div className='d-flex flex-column w-100'>
+        {isMuted && <Alert message='⚠️ You muted this account' type='warning' className='mb-3' />}
         <div className='d-flex mb-3'>
           <Avatar
             size={size || LARGE_AVATAR_SIZE}

--- a/src/rtk/features/posts/postsHooks.ts
+++ b/src/rtk/features/posts/postsHooks.ts
@@ -22,9 +22,12 @@ export function useIsMuted(address: string) {
   return mutedAccounts?.includes(address) ?? false
 }
 
-export const useSelectPost = (postId?: PostId): PostWithSomeDetails | undefined => {
+export const useSelectPost = (
+  postId?: PostId,
+  showMuted?: boolean,
+): PostWithSomeDetails | undefined => {
   const struct = useAppSelector(state => (postId ? selectPostStructById(state, postId) : undefined))
-  const isMuted = useIsMuted(struct?.ownerId || '')
+  const isMuted = useIsMuted(struct?.ownerId || '') && !showMuted
 
   const cid = struct?.contentId
   const content = useAppSelector(state => (cid ? selectPostContentById(state, cid) : undefined))


### PR DESCRIPTION
If user accesses muted account's profile page, then they will still see all their activities
And you will see alert that he's muted there

Hide reactions tab in profile activity