### PR TITLE
Fix notification counter not showing correctly

### DIFF
--- a/src/components/activity/MyNotifications.tsx
+++ b/src/components/activity/MyNotifications.tsx
@@ -1,6 +1,8 @@
+import { useMyAccount } from 'src/stores/my-account'
 import { useMyAddress } from '../auth/MyAccountsContext'
 import NotAuthorized from '../auth/NotAuthorized'
 import { PageContent } from '../main/PageWrapper'
+import { Loading } from '../utils'
 import { Notifications } from './Notifications'
 import styles from './style.module.sass'
 
@@ -8,12 +10,17 @@ const NOTIFICATION_TITLE = 'My notifications'
 
 export const MyNotifications = () => {
   const myAddress = useMyAddress()
+  const isInitializedProxy = useMyAccount(state => state.isInitializedProxy)
 
   if (!myAddress) return <NotAuthorized />
 
   return (
     <PageContent meta={{ title: NOTIFICATION_TITLE }} className={styles.NotificationPage}>
-      <Notifications title={NOTIFICATION_TITLE} address={myAddress} />
+      {!isInitializedProxy ? (
+        <Loading center />
+      ) : (
+        <Notifications title={NOTIFICATION_TITLE} address={myAddress} />
+      )}
     </PageContent>
   )
 }

--- a/src/components/activity/Notification.tsx
+++ b/src/components/activity/Notification.tsx
@@ -111,8 +111,8 @@ const iconByEvent: Record<string, React.ReactNode> = {
 export function InnerNotification(props: InnerNotificationProps) {
   const myAddress = useMyAddress()
 
-  const { lastReadNotif } = useNotifCounterContext()
-  const showUnreadBadge = new Date(lastReadNotif ?? new Date()) < new Date(props.date)
+  const { previousLastRead } = useNotifCounterContext()
+  const showUnreadBadge = new Date(previousLastRead ?? new Date()) < new Date(props.date)
 
   const {
     preview,

--- a/src/components/activity/Notifications.tsx
+++ b/src/components/activity/Notifications.tsx
@@ -82,9 +82,7 @@ export const Notifications = ({ address, title }: BaseActivityProps) => {
   const { updateLastReadNotification } = useNotifCounterContext()
 
   useEffect(() => {
-    return () => {
-      updateLastReadNotification(new Date().toISOString())
-    }
+    updateLastReadNotification(new Date().toISOString())
   }, [])
 
   const getAllNotifications = useGetAllNotifications()


### PR DESCRIPTION
# Issue
Previously, because myAddress changes when the user has proxy, it fetches multiple data and causes it to have wrong data, which gets the last read from grill address instead of the real address