### PR TITLE
Fix permission

### DIFF
--- a/src/components/profile-selector/MyAccountMenu.tsx
+++ b/src/components/profile-selector/MyAccountMenu.tsx
@@ -91,6 +91,7 @@ export const AccountMenu: React.FunctionComponent<AddressProps> = ({ address, ow
         setIsOpenProfileModal(false)
       } else if (name === 'redirect') {
         router.push(value)
+        setIsOpenProfileModal(false)
       } else if (name === 'redirect-hard') {
         // Using router push for redirect don't redirect properly, it just have loading for a bit and changes the url much later
         window.location.href = value

--- a/src/components/spaces/roles/utils.tsx
+++ b/src/components/spaces/roles/utils.tsx
@@ -27,11 +27,11 @@ export const useCheckCanEditAndHideSpacePermission = ({ post: { struct }, space 
         updateOwn: 'HideOwnPosts',
       }
 
-  const canHidePost = isMyPost && checkSpacePermission(hideOwn)
-  // || checkSpacePermission('HideAnyPost')
+  const canHidePost =
+    (isMyPost && checkSpacePermission(hideOwn)) || checkSpacePermission('HideAnyPost')
 
-  const canEditPost = isMyPost && checkSpacePermission(updateOwn)
-  // || checkSpacePermission('UpdateAnyPost')
+  const canEditPost =
+    (isMyPost && checkSpacePermission(updateOwn)) || checkSpacePermission('UpdateAnyPost')
 
   const canMovePost = isMyPost && !isComment
 

--- a/src/components/spaces/roles/utils.tsx
+++ b/src/components/spaces/roles/utils.tsx
@@ -28,10 +28,12 @@ export const useCheckCanEditAndHideSpacePermission = ({ post: { struct }, space 
       }
 
   const canHidePost =
-    (isMyPost && checkSpacePermission(hideOwn)) || checkSpacePermission('HideAnyPost')
+    (isMyPost && checkSpacePermission(hideOwn)) ||
+    (!isComment && checkSpacePermission('HideAnyPost'))
 
   const canEditPost =
-    (isMyPost && checkSpacePermission(updateOwn)) || checkSpacePermission('UpdateAnyPost')
+    (isMyPost && checkSpacePermission(updateOwn)) ||
+    (!isComment && checkSpacePermission('UpdateAnyPost'))
 
   const canMovePost = isMyPost && !isComment
 


### PR DESCRIPTION
# Issue
Currently, post owner can't hide any posts, even if their permission in the space says it can

## Related Issue
#280 
This PR is reverted, because the permission is correct, the issue is in comment, in blockchain it has extra checker `posts.NotACommentAuthor`, while its not there in regular posts
So as a space owner I can hide/edit all posts in my space, but not comments
