### PR TITLE
Fix incorrect hiding posts behavior

### DIFF
--- a/src/components/posts/LatestPostsPage.tsx
+++ b/src/components/posts/LatestPostsPage.tsx
@@ -254,6 +254,7 @@ const InfiniteListOfPublicPosts = (props: Props) => {
         getKey={postId => postId}
         renderItem={postId => (
           <PublicPostPreviewById
+            shouldHideChatRooms={filter === 'hot'}
             showPinnedIcon={
               (isSuggested(filter) || filter === 'hot') && !postId.includes('promoted')
             }

--- a/src/components/posts/PublicPostPreview.tsx
+++ b/src/components/posts/PublicPostPreview.tsx
@@ -10,10 +10,11 @@ type Props = {
   showPinnedIcon?: boolean
   isPromoted?: boolean
   showMuted?: boolean
+  shouldHideChatRooms?: boolean
 }
 
 export const PublicPostPreviewById = React.memo(
-  ({ postId, showPinnedIcon, showMuted, isPromoted }: Props) => {
+  ({ postId, showPinnedIcon, showMuted, isPromoted, shouldHideChatRooms }: Props) => {
     const post = useSelectPost(postId, showMuted)
     const { value: showLikeablePostOnly } = useShowLikeablePostsContext()
     const { validByCreatorMinStake } = useCanPostSuperLiked(postId)
@@ -26,6 +27,7 @@ export const PublicPostPreviewById = React.memo(
         withActions
         showPinnedIcon={showPinnedIcon}
         isPromoted={isPromoted}
+        shouldHideChatRooms={shouldHideChatRooms}
       />
     )
   },

--- a/src/components/posts/view-post/PostPreview.tsx
+++ b/src/components/posts/view-post/PostPreview.tsx
@@ -34,8 +34,14 @@ export type PreviewProps = BarePreviewProps & {
   isPromoted?: boolean
 }
 
-// grill by subsocial and grilled space (spaces of chat room posts)
-const HIDE_PREVIEW_FROM_SPACE: string[] = ['12660', '12659']
+const HIDE_PREVIEW_FROM_SPACE: string[] = [
+  '12660', // Grill by Subsocial
+  '12659', // Grilled
+  '12662', // Offchain Chats
+  '12661', // Grill Widgets
+  '12455', // Community Chats
+  '12410', // Sandbox Highlights
+]
 export function PostPreview(props: PreviewProps) {
   const router = useRouter()
   const { postDetails, space: externalSpace, showPinnedIcon, shouldHideChatRooms } = props

--- a/src/components/posts/view-post/PostPreview.tsx
+++ b/src/components/posts/view-post/PostPreview.tsx
@@ -27,20 +27,18 @@ export type BarePreviewProps = {
 }
 
 export type PreviewProps = BarePreviewProps & {
+  shouldHideChatRooms?: boolean
   postDetails: PostWithSomeDetails
   space?: SpaceData
   showPinnedIcon?: boolean
   isPromoted?: boolean
 }
 
-// grill admin account and grill memes admin
-const HIDE_PREVIEW_FROM_ACCOUNT = [
-  '3rPYmfYVHG7NtuGDivDNZdMMRHgrwtVuswY9TWUaHQCU8tAo',
-  '3oGjkULuNKRqi513BbohWiSgA2oKMrbSnPrcddpXYC4mtW1G',
-]
+// grill by subsocial and grilled space (spaces of chat room posts)
+const HIDE_PREVIEW_FROM_SPACE: string[] = ['12660', '12659']
 export function PostPreview(props: PreviewProps) {
   const router = useRouter()
-  const { postDetails, space: externalSpace, showPinnedIcon } = props
+  const { postDetails, space: externalSpace, showPinnedIcon, shouldHideChatRooms } = props
   const myAddress = useMyAddress()
   const {
     space: globalSpace,
@@ -49,7 +47,8 @@ export function PostPreview(props: PreviewProps) {
   const { isSharedPost } = post
   const space = externalSpace || globalSpace
   const isUnlisted = useIsUnlistedPost({ post, space: space?.struct })
-  const isHiddenPreview = HIDE_PREVIEW_FROM_ACCOUNT.includes(post.ownerId)
+  const isHiddenChatRoom =
+    shouldHideChatRooms && HIDE_PREVIEW_FROM_SPACE.includes(post.spaceId ?? '')
 
   const { inView, ref } = useInView()
   useEffect(() => {
@@ -85,7 +84,7 @@ export function PostPreview(props: PreviewProps) {
     }
   }, [inView, myAddress])
 
-  if (isUnlisted || isHiddenPreview) return null
+  if (isUnlisted || isHiddenChatRoom) return null
 
   const postContent = postDetails.post.content
   const isEmptyContent = !isSharedPost && !postContent?.title && !postContent?.body


### PR DESCRIPTION
Owner who created grill's chat rooms posts are having all its posts previews hidden
Now its changed to only hidden in hot posts, and also the validation is made using the spaceId, not the creator