### PR TITLE
Minor Improvements

### DIFF
--- a/src/components/posts/editor/FullEditor.tsx
+++ b/src/components/posts/editor/FullEditor.tsx
@@ -195,7 +195,10 @@ const FullEditor = ({
       <Row className={styles.EditorContainer} gutter={[16, 16]} justify='center'>
         <Col
           style={{ minWidth: 0 }}
-          className={clsx('d-flex align-items-stretch flex-column', styles.EditorBodyContent)}
+          className={clsx(
+            'd-flex align-items-stretch flex-column',
+            styles.EditorBodyContentContainer,
+          )}
         >
           <Card className={clsx(styles.EditorBodyContent, 'mb-3')}>
             <Form.Item

--- a/src/components/posts/editor/ModalEditor.tsx
+++ b/src/components/posts/editor/ModalEditor.tsx
@@ -105,7 +105,7 @@ export const PostEditorModalBody = ({
   const [spaceId, setSpaceId] = useState<string>(defaultSpace)
 
   const { loading } = useFetchSpaces({ ids: spaceIds, dataSource: DataSourceTypes.SQUID })
-  const { saveContent } = useAutoSaveFromForm({ entity: 'post' })
+  const { savedData, saveContent } = useAutoSaveFromForm({ entity: 'post' })
 
   useEffect(() => {
     setSpaceId(defaultSpace)
@@ -201,7 +201,7 @@ export const PostEditorModalBody = ({
   )
 
   return (
-    <Form form={form} className='my-0' onFieldsChange={() => saveDraft()}>
+    <Form form={form} className='my-0' initialValues={savedData} onFieldsChange={() => saveDraft()}>
       <SpaceSelector />
       <Form.Item name={fieldName('body')} className='my-3'>
         {/* value and onChange are provided by Form.Item */}

--- a/src/components/posts/editor/index.module.sass
+++ b/src/components/posts/editor/index.module.sass
@@ -35,6 +35,9 @@
   \:global .ant-tabs-nav
     margin: 0
 
+.EditorBodyContentContainer
+  width: $max_width_content
+
 .AdvancedBody
   width: 325px
 


### PR DESCRIPTION
- Fix width change in full editor when change tab to video
- Use same draft as full editor when opening modal editor (because it uses same draft key, it makes sense to load the same data as its initial data)